### PR TITLE
full url in coverImage

### DIFF
--- a/apps/datajournalism.studio/app/a/[slug]/page.tsx
+++ b/apps/datajournalism.studio/app/a/[slug]/page.tsx
@@ -23,10 +23,17 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     // Construct the full URL for the article (replace with your actual domain)
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.datajournalism.studio'
     const articleUrl = `${baseUrl}/a/${params.slug}`
+
+    const isAbsoluteUrl = (value: unknown): value is string => {
+      if (typeof value !== 'string') return false;
+      return value.startsWith('http://') || value.startsWith('https://') || value.startsWith('//');
+    };
     
     // Construct the full image URL
     const imageUrl = article.coverImage 
-      ? `${baseUrl}/a/_articles/${params.slug}/${article.coverImage}`
+      ? (isAbsoluteUrl(article.coverImage)
+          ? article.coverImage
+          : `${baseUrl}/a/_articles/${params.slug}/${article.coverImage}`)
       : `${baseUrl}/default-og-image.jpg` // Fallback image
 
     return {

--- a/apps/datajournalism.studio/components/common/getArticles.ts
+++ b/apps/datajournalism.studio/components/common/getArticles.ts
@@ -29,12 +29,17 @@ export async function getArticles(
   const articleFolders = fs.readdirSync(articlesDirectory);
   const currentDate = new Date();
 
+  const isAbsoluteUrl = (value: unknown): value is string => {
+    if (typeof value !== 'string') return false;
+    return value.startsWith('http://') || value.startsWith('https://') || value.startsWith('//');
+  };
+
   const articles = articleFolders.map((folder) => {
     const fullPath = path.join(articlesDirectory, folder, 'index.md');
     const fileContents = fs.readFileSync(fullPath, 'utf8');
     const { data } = matter(fileContents);
     const coverImage = data.coverImage
-      ? `/a/_articles/${folder}/${data.coverImage}`
+      ? (isAbsoluteUrl(data.coverImage) ? data.coverImage : `/a/_articles/${folder}/${data.coverImage}`)
       : null;
 
     return {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Supports absolute `coverImage` URLs across article metadata and listings.
> 
> - Add `isAbsoluteUrl` helper in `app/a/[slug]/page.tsx` and `components/common/getArticles.ts`
> - In `generateMetadata`, use `coverImage` as-is when absolute; otherwise prefix with `baseUrl` and slug; retain fallback image
> - In `getArticles`, preserve absolute `coverImage` values; otherwise build `/a/_articles/<folder>/<file>` path
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f84f92d3a38898a473d3092c5048b45a9d1f932d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->