### PR TITLE
author at the article page

### DIFF
--- a/apps/datajournalism.studio/components/a/ArticleRenderer.tsx
+++ b/apps/datajournalism.studio/components/a/ArticleRenderer.tsx
@@ -17,6 +17,7 @@ interface ArticleProps {
   mdxSource: MDXRemoteSerializeResult;
   title?: string;
   date?: string;
+  author?: string;
   slug: string;
   scrollyContent?: any; // Add scrollyContent to the ArticleProps
   backgroundColor?: string;  // Optional background color
@@ -28,6 +29,7 @@ export function ArticleRenderer({
   mdxSource,
   title,
   date,
+  author,
   slug = '',
   scrollyContent,
   backgroundColor,
@@ -208,6 +210,7 @@ export function ArticleRenderer({
 
         {date && (
           <Text size="sm" c={textColor || "dimmed"}>
+            {author ? `${author.toUpperCase()} • ` : ''}
             {new Date(date).toLocaleDateString('en-US', {
               year: 'numeric',
               month: 'long',

--- a/apps/web/components/clanek/ArticleRenderer.tsx
+++ b/apps/web/components/clanek/ArticleRenderer.tsx
@@ -20,6 +20,7 @@ interface ArticleProps {
   mdxSource: MDXRemoteSerializeResult;
   title?: string;
   date?: string;
+  author?: string;
   slug: string;
   scrollyContent?: any;     // Add scrollyContent to the ArticleProps
   backgroundColor?: string;  // Optional background color
@@ -31,6 +32,7 @@ export function ArticleRenderer({
   mdxSource,
   title,
   date,
+  author,
   slug = '',
   scrollyContent,
   backgroundColor,
@@ -218,6 +220,7 @@ export function ArticleRenderer({
 
         {date && (
           <Text size="sm" c={textColor || "dimmed"}>
+            {author ? `${author.toUpperCase()} • ` : ''}
             {new Date(date).toLocaleDateString('cs-CZ')}
           </Text>
         )}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds author metadata to article headers.
> 
> - Introduces optional `author` to `ArticleRenderer` props in both `apps/datajournalism.studio` and `apps/web`
> - Renders `AUTHOR •` before the formatted date (`en-US` vs `cs-CZ` locale preserved)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3150b6e414fc8cf8ab50f642d1725e03719cf57b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->