### PR TITLE
authors' pages

### DIFF
--- a/apps/datajournalism.studio/app/a/_articles/2024-07-08-electoral-forensic-case-study/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2024-07-08-electoral-forensic-case-study/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Case Study: Electoral Forensics in European Parliament Election"  
 date: "2024-07-08"  
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "We identified errors in counting electoral votes in several polling stations."  
 coverImage: "images/main.png"  
 filter: ["blog"]  

--- a/apps/datajournalism.studio/app/a/_articles/2024-10-10-digitalizace-stavebniho-rizeni-analyza-prvnich-dostupnych-dat/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2024-10-10-digitalizace-stavebniho-rizeni-analyza-prvnich-dostupnych-dat/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Digitalizace stavebního řízení: Analýza prvních dostupných dat"
 date: "2024-10-10"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "První data z digitalizovaného systému stavebních řízení (DSŘ): systém zvládá rostoucí objem žádostí bez zjevných známek přetížení."
 coverImage: "images/main.png"
 filter: ["analýza"]

--- a/apps/datajournalism.studio/app/a/_articles/2024-10-17-za-sevcika-se-rekordne-propadl-zajem-uchazecu-o-studium-nejvic-ze-vsech-verejnych-vysokych-skol-v-cr/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2024-10-17-za-sevcika-se-rekordne-propadl-zajem-uchazecu-o-studium-nejvic-ze-vsech-verejnych-vysokych-skol-v-cr/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Za Ševčíka se rekordně propadl zájem uchazečů o studium. Nejvíc ze všech veřejných VŠ v ČR"
 date: "2024-10-17"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Škodí odvolaný děkan (nyní opět proděkan) Miroslav Ševčík národohospodářské fakultě?"
 coverImage: "images/overview.png"
 filter: ""

--- a/apps/datajournalism.studio/app/a/_articles/2024-10-31-volebni-model/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2024-10-31-volebni-model/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Volební model: Kdo má šanci na křesla ve Sněmovně a kdo bude vládnout"
 date: "2024-10-31"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Kdyby se dnes konaly volby, čtyřkoalice by se nad vodou držela jen stěží."
 coverImage: "images/poll_tracker.png"
 filter: [""]

--- a/apps/datajournalism.studio/app/a/_articles/2024-11-05-USA-volby/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2024-11-05-USA-volby/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Predikce, která se vám nebude líbit"
 date: "2024-11-05"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Čekáte těsné vítězství Trumpa či Harris? Vůbec to tak být nemusí. Ukážeme vám, že rozdíly mohou být mnohem větší a že to není chyba průzkumných agentur."
 coverImage: "images/USA_volby_predikce.png"
 filter: ["analýza"]

--- a/apps/datajournalism.studio/app/a/_articles/2024-11-06-USA-volby/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2024-11-06-USA-volby/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Volby vyhraje Trump a nebude to těsně"
 date: "2024-11-06"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Naše predikce ukazuje s 80% jistotou, že příštím americkým prezidentem se stane Donald Trump."
 coverImage: "images/USA-volby-2024-predikce.png"
 filter: ["analýza"]

--- a/apps/datajournalism.studio/app/a/_articles/2024-11-14-Amsterdam-video/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2024-11-14-Amsterdam-video/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Jak se živí nenávist: příběh jednoho videa"
 date: "2024-11-14"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Jedno video, špatný kontext a příběh, který ilustruje, jak snadno může dojít k manipulaci veřejného mínění."
 coverImage: "images/amsterdam-udalosti.png"
 filter: ["kontext"]

--- a/apps/datajournalism.studio/app/a/_articles/2024-11-21-netanjahu-icc-zeme-rimsky-statut/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2024-11-21-netanjahu-icc-zeme-rimsky-statut/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Mezinárodní trestní soud vydal zatykač na Netanjahua a Gallanta"
 date: "2024-11-21"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Politici jsou oficiálně obviněni z válečných zločinů a zločinů proti lidskosti."
 coverImage: "images/Rimsky-statut-zeme-s-pozadim.png"
 filter: ["kontext"]

--- a/apps/datajournalism.studio/app/a/_articles/2024-11-27-Rakousko-kartogramy/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2024-11-27-Rakousko-kartogramy/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Naše kartogramy oceňují i v Rakousku"
 date: "2024-11-27"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Pochval a uznání není nikdy dost 😊⁣ Naše kartogramy si jako ukázkové vybrali nejvyšší statistici Rakouska."
 coverImage: "images/Rakousko-kartogramy.png"
 filter: ["kontext"]

--- a/apps/datajournalism.studio/app/a/_articles/2024-11-27-austria-cartogram/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2024-11-27-austria-cartogram/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Austrian Cartogram Recognized as an Example of Good Practice."  
 date: "2024-11-27"  
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Our cartograms have been selected as exemplary by the official Statistik Austria."  
 coverImage: "images/main.png"  
 filter: ["blog"] 

--- a/apps/datajournalism.studio/app/a/_articles/2024-12-08-Rumunsko-volby/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2024-12-08-Rumunsko-volby/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Rumunsko: Krize demokracie u prezidentských voleb"
 date: "2024-12-08"  
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Anulování prezidentských voleb kvůli hybridnímu útoku odhaluje zranitelnost demokratických procesů."  
 coverImage: "images/Rumunsko-volby-zruseno-2024.png
 "

--- a/apps/datajournalism.studio/app/a/_articles/2024-12-19-European-parliament-who-is-voting-with-who/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2024-12-19-European-parliament-who-is-voting-with-who/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Members of the European Parliament: Who Votes with Whom, Who is Part of the European Mainstream, and Who is Not"  
 date: "2024-12-19"  
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "European Parliament 2024."  
 coverImage: "images/main.png"  
 filter: ["blog"] 

--- a/apps/datajournalism.studio/app/a/_articles/2024-12-20-Rumunsko-volby-EU/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2024-12-20-Rumunsko-volby-EU/index.md
@@ -2,7 +2,7 @@
 
 title: "Rumunsko v epicentru hybridní války. Stejně jako my"  
 date: "2024-12-20"  
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Hybridní kampaně, manipulace algoritmů a vlivové operace ukazují, jak lze destabilizovat demokratické procesy."  
 coverImage: "images/main.webp"  
 filter: ["kontext"]  

--- a/apps/datajournalism.studio/app/a/_articles/2025-02-21-election-germany-cartogram/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2025-02-21-election-germany-cartogram/index.md
@@ -1,7 +1,7 @@
 ---
 title: "German Elections: How Voting Works and How to Read the Results Correctly"  
 date: "2025-02-21"  
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "The German parliamentary elections will take place on Sunday. Why traditional election maps are not always the best choice and how to interpret the results correctly."  
 coverImage: "images/step_13.png"  
 filter: ["blog"]  

--- a/apps/datajournalism.studio/app/a/_articles/2025-02-28-elections-germany/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2025-02-28-elections-germany/index.md
@@ -1,7 +1,7 @@
 ---
 title: "German Elections: Did the Eastern Bloc Vote Radically? Not Exactly"
 date: "2025-02-28"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "The German parliamentary elections were held on Sunday. At first glance, it may seem that former East Germany has become radicalized, but this is quite a distorted view."
 coverImage: "images/map_cartogram_germany_winner.webp"
 filter: ["blog"]

--- a/apps/datajournalism.studio/app/a/_articles/2025-05-20-money-from-nowhere-the-mysterious-millions-of-mep-turek/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/2025-05-20-money-from-nowhere-the-mysterious-millions-of-mep-turek/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Money from Nowhere: The Mysterious Millions of MEP Turek"
 date: "2025-05-20"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "In the financial declarations of Czech MEP Filip Turek, we have uncovered major discrepancies that raise fundamental questions: where do his declared incomes actually come from, and why do his claims and financial statements completely contradict each other?"
 coverImage: "images/main.webp"
 filter: ["blog"]

--- a/apps/datajournalism.studio/app/a/_articles/elections-forensic-analysis/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/elections-forensic-analysis/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Data-driven Analytical Election Forensics"  
 date: "2024-07-08"  
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Analytical methods to detect irregularities in election results."  
 coverImage: "images/main.png"  
 filter: ["work"]  

--- a/apps/datajournalism.studio/app/a/_articles/elections-maps-of-results/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/elections-maps-of-results/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Maps of Election Results: Deeper Insights on First Sight"  
 date: "2024-11-10"  
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Telling the detailed story of the elections."  
 coverImage: "images/main.png"  
 filter: ["work"]  

--- a/apps/datajournalism.studio/app/a/_articles/elections-real-time-predictions/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/elections-real-time-predictions/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Real-Time Predictions of Election Results: The New Normal"  
 date: "2024-09-20"  
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Real-time predictions are reshaping election nights."  
 coverImage: "images/main.png"  
 filter: ["work"]  

--- a/apps/datajournalism.studio/app/a/_articles/elections-voters-shifts/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/elections-voters-shifts/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Voter Shifts Between Elections: Insights from Statistical Analysis"  
 date: "2024-06-30"  
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Detailed data analysis reveal hidden changes between elections."  
 coverImage: "images/main.png"  
 filter: ["work"]  

--- a/apps/datajournalism.studio/app/a/_articles/voting-advice-applications/index.md
+++ b/apps/datajournalism.studio/app/a/_articles/voting-advice-applications/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Voting Advice Applications - The Most Popular Pre-Election Apps"
 date: "2025-01-01"
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "How voting advice applications increase informed political participation."  
 coverImage: "images/main.png"  
 filter: ["work"]  

--- a/apps/datajournalism.studio/app/author/[slug]/page.tsx
+++ b/apps/datajournalism.studio/app/author/[slug]/page.tsx
@@ -1,0 +1,50 @@
+// app/author/[slug]/page.tsx
+import { getArticles } from '@/components/common/getArticles';
+import { ArticlesSection } from '@/components/common/ArticlesSection';
+import { Container } from '@mantine/core';
+import SubscribeNewsletter from '@/components/common/SubscribeNewsletter';
+import { getAllAuthors } from '@/utils/authorServerUtils';
+import { normalizeAuthor, splitAuthors } from '@/utils/authorUtils';
+import { notFound } from 'next/navigation';
+
+interface PageProps {
+  params: {
+    slug: string;
+  };
+}
+
+export async function generateStaticParams() {
+  const authorMap = await getAllAuthors();
+  const authors = Array.from(authorMap.keys());
+  console.log('Generated static paths for authors:', authors);
+  return authors.map((author) => ({ slug: author }));
+}
+
+export default async function Page({ params }: PageProps) {
+  const { slug } = params;
+
+  const authorMap = await getAllAuthors();
+  const originalAuthor = authorMap.get(slug);
+
+  if (!originalAuthor) {
+    notFound();
+  }
+
+  const allArticles = await getArticles(100);
+  const articles = allArticles.filter((article) =>
+    splitAuthors(article.author).some((a) => normalizeAuthor(a) === slug)
+  );
+
+  if (!articles || articles.length === 0) {
+    notFound();
+  }
+
+  return (
+    <Container size="lg" maw="1200px" w="100%" p={0} m="0 auto">
+      <>
+        <ArticlesSection sectionTitle={`${originalAuthor}`} articles={articles} themeColor="brandRoyalBlue.3" />
+        <SubscribeNewsletter actionUrl='https://mahdalovaskop.ecomailapp.cz/public/subscribe/1/43c2cd496486bcc27217c3e790fb4088' />
+      </>
+    </Container>
+  );
+}

--- a/apps/datajournalism.studio/utils/authorServerUtils.ts
+++ b/apps/datajournalism.studio/utils/authorServerUtils.ts
@@ -1,0 +1,33 @@
+// utils/authorServerUtils.ts
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { normalizeAuthor, splitAuthors } from '@/utils/authorUtils';
+
+export async function getAllAuthors(): Promise<Map<string, string>> {
+  const articlesDirectory = path.join(process.cwd(), 'app/a/_articles');
+  const authorMap = new Map<string, string>();
+
+  try {
+    const articleFolders = fs.readdirSync(articlesDirectory);
+
+    articleFolders.forEach((folder) => {
+      const fullPath = path.join(articlesDirectory, folder, 'index.md');
+      const fileContents = fs.readFileSync(fullPath, 'utf8');
+      const { data } = matter(fileContents);
+
+      const authors = splitAuthors(data.author);
+      authors.forEach((name) => {
+        const normalized = normalizeAuthor(name);
+        if (!normalized) return;
+        if (!authorMap.has(normalized)) {
+          authorMap.set(normalized, name);
+        }
+      });
+    });
+  } catch (err) {
+    console.error('Error reading authors:', err);
+  }
+
+  return authorMap;
+}

--- a/apps/datajournalism.studio/utils/authorUtils.ts
+++ b/apps/datajournalism.studio/utils/authorUtils.ts
@@ -1,0 +1,31 @@
+// utils/authorUtils.ts
+export function normalizeAuthor(author: string): string {
+  return author
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function splitAuthors(author: unknown): string[] {
+  if (!author) return [];
+
+  if (Array.isArray(author)) {
+    return author
+      .filter((a): a is string => typeof a === 'string')
+      .map((a) => a.trim())
+      .filter(Boolean);
+  }
+
+  if (typeof author === 'string') {
+    return author
+      .split(/,|&|\s+and\s+|\s+a\s+/i)
+      .map((a) => a.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+}

--- a/apps/web/app/autor/[slug]/page.tsx
+++ b/apps/web/app/autor/[slug]/page.tsx
@@ -1,0 +1,50 @@
+// app/autor/[slug]/page.tsx
+import { getArticles } from '@/components/common/getArticles';
+import { ArticlesSection } from '@/components/common/ArticlesSection';
+import { Container } from '@mantine/core';
+import SubscribeNewsletter from '@/components/common/SubscribeNewsletter';
+import { getAllAuthors } from '@/utils/authorServerUtils';
+import { normalizeAuthor, splitAuthors } from '@/utils/authorUtils';
+import { notFound } from 'next/navigation';
+
+interface PageProps {
+  params: {
+    slug: string;
+  };
+}
+
+export async function generateStaticParams() {
+  const authorMap = await getAllAuthors();
+  const authors = Array.from(authorMap.keys());
+  console.log('Generated static paths for authors:', authors);
+  return authors.map((author) => ({ slug: author }));
+}
+
+export default async function Page({ params }: PageProps) {
+  const { slug } = params;
+
+  const authorMap = await getAllAuthors();
+  const originalAuthor = authorMap.get(slug);
+
+  if (!originalAuthor) {
+    notFound();
+  }
+
+  const allArticles = await getArticles(100);
+  const articles = allArticles.filter((article) =>
+    splitAuthors(article.author).some((a) => normalizeAuthor(a) === slug)
+  );
+
+  if (!articles || articles.length === 0) {
+    notFound();
+  }
+
+  return (
+    <Container size="lg" maw="1200px" w="100%" p={0} m="0 auto">
+      <>
+        <ArticlesSection sectionTitle={`${originalAuthor}`} articles={articles} themeColor="brandRoyalBlue.3" />
+        <SubscribeNewsletter actionUrl='https://mahdalovaskop.ecomailapp.cz/public/subscribe/1/43c2cd496486bcc27217c3e790fb4088' />
+      </>
+    </Container>
+  );
+}

--- a/apps/web/app/clanek/_articles/analyza-2024-10-10-digitalizace-stavebniho-rizeni-analyza-prvnich-dostupnych-dat/index.md
+++ b/apps/web/app/clanek/_articles/analyza-2024-10-10-digitalizace-stavebniho-rizeni-analyza-prvnich-dostupnych-dat/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Digitalizace stavebního řízení: Analýza prvních dostupných dat"
 date: "2024-10-10"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "První data z digitalizovaného systému stavebních řízení (DSŘ): systém zvládá rostoucí objem žádostí bez zjevných známek přetížení."
 coverImage: "images/main.png"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/analyza-2024-10-17-za-sevcika-se-rekordne-propadl-zajem-uchazecu-o-studium/index.md
+++ b/apps/web/app/clanek/_articles/analyza-2024-10-17-za-sevcika-se-rekordne-propadl-zajem-uchazecu-o-studium/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Za Ševčíka se rekordně propadl zájem uchazečů o studium. Nejvíc ze všech veřejných VŠ v ČR"
 date: "2024-10-17"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Škodí odvolaný děkan (nyní opět proděkan) Miroslav Ševčík národohospodářské fakultě?"
 coverImage: "images/overview.png"
 filter: "analýza"

--- a/apps/web/app/clanek/_articles/analyza-2025-03-04-trumpova-obchodni-valka/index.md
+++ b/apps/web/app/clanek/_articles/analyza-2025-03-04-trumpova-obchodni-valka/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Trumpova obchodní válka"
 date: "2025-04-03"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Trump zavádí nejtvrdší obchodní opatření za poslední desítky let. Oznámil 10% clo na veškerý dovoz do země a k tomu sadu dodatečných cel na konkrétní státy – včetně klíčových spojenců, jako jsou země EU, Japonsko, Jižní Korea či Austrálie."
 coverImage: "images/trump-obchodni-valka-clo-world.jpg"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/analyza-2025-03-08-zeny-v-politice-cim-vyse-tim-mene-zen/index.md
+++ b/apps/web/app/clanek/_articles/analyza-2025-03-08-zeny-v-politice-cim-vyse-tim-mene-zen/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Ženy v politice? Čím výše, tím méně žen."  
 date: "2025-03-08"  
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Čím výš v politice, tím méně žen. Jak si vedou české kraje a proč jinde mají žen ve vedení víc?"  
 coverImage: "images/main.png"  
 filter: ["analýza"]  

--- a/apps/web/app/clanek/_articles/analyza-2025-05-13-jak-europoslanec-turek-doopravdy-zavodil-ve-formuli/index.md
+++ b/apps/web/app/clanek/_articles/analyza-2025-05-13-jak-europoslanec-turek-doopravdy-zavodil-ve-formuli/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Jak europoslanec Turek doopravdy závodil ve formuli"
 date: "2025-05-13"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Životní Turkův úspěch v závodech formulí byl závod v květnu 2017, kdy v nejslabší kategorii formulí porazil oba dva další jezdce: patnáctiletého juniora z Dominikánské republiky, který právě přesedlal z motokár, a obvodního lékaře z východního Německa. Více závodníků v jeho kategorii nejelo. Celkově v tomto závodě dojel čtvrtý od konce."
 coverImage: "images/helma.webp"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/analyza-2025-05-16-penize-odnikud-zahadne-miliony-europoslance-turka/index.md
+++ b/apps/web/app/clanek/_articles/analyza-2025-05-16-penize-odnikud-zahadne-miliony-europoslance-turka/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Peníze odnikud: Záhadné miliony europoslance Turka"
 date: "2025-05-16"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Ve finančních prohlášeních europoslance Turka jsme odhalili velké nesrovnalosti, které vyvolávají zásadní otázky: odkud skutečně plynou jeho deklarované příjmy a proč se jeho tvrzení a výkazy zcela rozcházejí?"
 coverImage: "images/main.webp"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/analyza-2025-08-25-40-dni-do-voleb-a-babis-na-95-premierem/index.md
+++ b/apps/web/app/clanek/_articles/analyza-2025-08-25-40-dni-do-voleb-a-babis-na-95-premierem/index.md
@@ -1,7 +1,7 @@
 ---
 title: "40 dní do voleb a Babiš na 95 % premiérem. Co by se ale stalo, kdyby soudy vyhověly žalobám na tzv. nepřiznané koalice?"
 date: "2025-08-24"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Zdá se být rozhodnuto. Soudní spory o 'skryté koalice' by ale mohly dramaticky změnit politickou mapu."
 coverImage: "images/main.webp"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/cislo-dne-2025-02-14-jedenact-milionu-otevreny-dopis-rektoratu-univerzity-karlovy/index.md
+++ b/apps/web/app/clanek/_articles/cislo-dne-2025-02-14-jedenact-milionu-otevreny-dopis-rektoratu-univerzity-karlovy/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Otevřený dopis pro vedení Univerzity Karlovy: vysvětlete, jak jste si rozdělili 11,5 milionu"
 date: "2025-02-14"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Akademická obec se ohrazuje proti vysokým odměnám pro vedení univerzity a proti uvedeným důvodům."
 coverImage: "images/uk-akademici-otevreny-dopis-proti-rektorce-a-vedeni.jpg"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/cislo-dne-2025-02-15-tri-ctvrtiny-umrti-z-horka-pripadaji-na-mlade-lidi/index.md
+++ b/apps/web/app/clanek/_articles/cislo-dne-2025-02-15-tri-ctvrtiny-umrti-z-horka-pripadaji-na-mlade-lidi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Změny klimatu: 75 % úmrtí způsobených horkem v Mexiku připadá na lidi mladší 35 let"
 date: "2025-02-15"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Zatímco dosavadní výzkumy varovaly před riziky pro seniory, aktuální data ukazují, že největší riziko představují vedra pro mladé lidi ve věku 18 až 35 let."
 coverImage: "images/image1.webp"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/cislo-dne-2025-03-03-v-kanade-se-vzedmula-liberalni-vlna/index.md
+++ b/apps/web/app/clanek/_articles/cislo-dne-2025-03-03-v-kanade-se-vzedmula-liberalni-vlna/index.md
@@ -1,7 +1,7 @@
 ---
 title: "V Kanadě se vzedmula liberální vlna"
 date: "2025-03-03"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Hned na začátku volebního roku došlo v Kanadě k velice rychlému zvratu ve voličských náladách. Liberálové mají podporu 38 %."
 coverImage: "images/kanada-volebni-model-brezen-2025.jpg"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/cislo-dne-2025-04-02-soudkyne-porazila-muska/index.md
+++ b/apps/web/app/clanek/_articles/cislo-dne-2025-04-02-soudkyne-porazila-muska/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Číslo dne: 20 milionů dolarů (nestačilo)"
 date: "2025-04-02"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "aneb Soudkyně Susan Crawford porazila Muska"
 coverImage: "images/cislo-dne-soudkyne-porazila-muska.jpg"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/europarlament-2024-12-17-kdo-z-ceska-a-slovenska-chybi-na-hlasovani/index.md
+++ b/apps/web/app/clanek/_articles/europarlament-2024-12-17-kdo-z-ceska-a-slovenska-chybi-na-hlasovani/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Europoslanci: Kdo z Česka a Slovenska chybí na hlasování"
 date: "2024-12-17"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Tento týden probíhá ve Štrasburku 9. zasedání Evropského parlamentu v tomto volebním období."
 coverImage: "images/main.webp"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/europarlament-2024-12-19-kdo-hlasuje-s-kym/index.md
+++ b/apps/web/app/clanek/_articles/europarlament-2024-12-19-kdo-hlasuje-s-kym/index.md
@@ -2,7 +2,7 @@
 title: "Europoslanci: Kdo hlasuje s kým, kdo je součást evropského
 mainstreamu a kdo je mimo"
 date: "2024-12-19"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Unikátní analýza shody hlasování v Europarlamentu za rok 2024."
 coverImage: "images/main.webp"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/europarlament-2024-12-23-kdo-hlasuje-pro-rusky/index.md
+++ b/apps/web/app/clanek/_articles/europarlament-2024-12-23-kdo-hlasuje-pro-rusky/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Europoslanci: Kdo hlasuje pro-rusky a kdo k Rusku kriticky"
 date: "2024-12-23"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Většina silně pro-rusky hlasujících europoslanců je jen ze 3 zemí: Německa, Slovenska a Česka."
 coverImage: "images/main.webp"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/explainer-2024-11-21-netanjahu-icc-zeme-rimsky-statut/index.md
+++ b/apps/web/app/clanek/_articles/explainer-2024-11-21-netanjahu-icc-zeme-rimsky-statut/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Mezinárodní trestní soud vydal zatykač na Netanjahua a Gallanta"
 date: "2024-11-21"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Politici jsou oficiálně obviněni z válečných zločinů a zločinů proti lidskosti."
 coverImage: "images/Rimsky-statut-zeme-s-pozadim.png"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/explainer-2025-01-06-znaky-fasismu-podle-eca/index.md
+++ b/apps/web/app/clanek/_articles/explainer-2025-01-06-znaky-fasismu-podle-eca/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Rusko a Ukrajina: čtrnáct znaků fašismu"
 date: "2025-01-06"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Proč by nás mělo zajímat, když někdo označí stát za fašistický? Podívejte se na varovné signály"
 coverImage: "images/Indikatory_fasismu_podle_Eca.png"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/explainer-2025-11-15-boj-o-rektora-vse-data-ukazuji-sevcikuv-propadak/index.md
+++ b/apps/web/app/clanek/_articles/explainer-2025-11-15-boj-o-rektora-vse-data-ukazuji-sevcikuv-propadak/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Volba rektora VŠE: co říkají data o Ševčíkově fakultě"
 date: "2025-11-15"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Akademický senát rozhodne, zda v čele VŠE zůstane ekonom Petr Dvořák, nebo poslanec SPD Miroslav Ševčík."
 coverImage: "images/vse-rektor-2025-dvorak-sevcik.webp"
 filter: "kontext"

--- a/apps/web/app/clanek/_articles/komentar-2025-01-09-hitler-nebyl-komunista/index.md
+++ b/apps/web/app/clanek/_articles/komentar-2025-01-09-hitler-nebyl-komunista/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Glosa: Hilter nebyl komunista"
 date: "2025-01-09"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Jak se nakládá s ideologickými nálepkami"
 coverImage: "images/Weidel_and_Musk.webp"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/komentar-2025-01-22-dezinformace-jako-nikdy/index.md
+++ b/apps/web/app/clanek/_articles/komentar-2025-01-22-dezinformace-jako-nikdy/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Glosa: Dezinformace jako nikdy"
 date: "2026-01-31"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Musk: Dezinformace jako nikdy"
 coverImage: "images/Weidel_and_Musk.webp"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/komentar-2025-02-05-snyder-samozrejme-ze-je-to-puc/index.md
+++ b/apps/web/app/clanek/_articles/komentar-2025-02-05-snyder-samozrejme-ze-je-to-puc/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Timothy Snyder: Samozřejmě, že je to puč"
 date: "2025-02-05"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Namísto ozbrojeného komanda přichází do vládních budov několik desítek mladých mužů v civilu, vyzbrojených pouze flash disky."
 coverImage: "images/komentar-timothy-snyder-usa-je-to-puc-2025.jpg"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/komentar-2025-03-01-jsme-s-ukrajinou/index.md
+++ b/apps/web/app/clanek/_articles/komentar-2025-03-01-jsme-s-ukrajinou/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Obviňování oběti: Trumpova diplomacie v područí autoritářů"
 date: "2025-03-01"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Role Spojených států coby garanta stability se změnila. Trumpova diplomacie nyní obviňuje oběť, oslabuje spojence a posiluje agresora."
 coverImage: "images/ukrajina-zelensky.jpg"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/kontext-2024-11-14-amsterdam-video/index.md
+++ b/apps/web/app/clanek/_articles/kontext-2024-11-14-amsterdam-video/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Jak se živí nenávist: příběh jednoho videa"
 date: "2024-11-14"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Jedno video, špatný kontext a příběh, který ilustruje, jak snadno může dojít k manipulaci veřejného mínění."
 coverImage: "images/amsterdam-udalosti.png"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/kontext-2025-04-03-americka-cla-trest-za-to-ze-jste-moc-dobri/index.md
+++ b/apps/web/app/clanek/_articles/kontext-2025-04-03-americka-cla-trest-za-to-ze-jste-moc-dobri/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Americká cla: Trest za to, že jste moc dobří"
 date: "2025-04-03"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Prezident Trump představil nová cla na dovoz do USA — třeba 20 % na zboží z EU. Říká jim „reciproční“, ale ve skutečnosti jsou to cla z obchodního schodku."
 coverImage: "images/trump_clown.webp"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/kontext-2025-05-14-europoslanec-turek-prezident-dvou-spolku/index.md
+++ b/apps/web/app/clanek/_articles/kontext-2025-05-14-europoslanec-turek-prezident-dvou-spolku/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Europoslanec Turek: Prezident dvou spolků, jeden má 3 členy, druhý nefunguje"
 date: "2025-05-14"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Pokračujeme v odhalování skutečného příběhu europoslance Filipa Turka (Motoristé/Patrioti). Po prozkoumání jeho závodní kariéry se nyní zaměřujeme na další oblast jeho veřejné prezentace."
 coverImage: "images/main.webp"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/kontext-2025-05-22-bezpodminecna-podpora-izraele-poskozuje-nasi-bezpecnost/index.md
+++ b/apps/web/app/clanek/_articles/kontext-2025-05-22-bezpodminecna-podpora-izraele-poskozuje-nasi-bezpecnost/index.md
@@ -1,7 +1,7 @@
 ---
 title: "🛑 Nebezpečná izolace: Proč česká bezpodmínečná podpora Izraele poškozuje naši bezpečnost"
 date: "2025-05-22"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "V době, kdy spojenci Česka vyzývají k zastavení humanitární katastrofy v Gaze, česká vláda zůstává loajální izraelské politice – i za cenu mezinárodní izolace. Podporuje tím nejen okupaci, ale i oslabení právního řádu, na kterém sama staví svoji obranu proti ruské agresi."
 coverImage: "images/palestine-gaza-israel-news.jpg"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/kontext-2025-06-06-musk-a-techbros-odstreli-trumpa/index.md
+++ b/apps/web/app/clanek/_articles/kontext-2025-06-06-musk-a-techbros-odstreli-trumpa/index.md
@@ -1,7 +1,7 @@
 ---
 title: "🤖 Možnost: Musk a techbros odstřelí Trumpa a nastoupí Vance"
 date: "2025-06-06"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Mezi Donaldem Trumpem a Elonem Muskem viditelně došlo k zásadnímu rozkolu. Donedávna spojenci, které spojovala cynická hra na svobodu, se po dnešní noci ocitají na opačných stranách barikády."
 coverImage: "images/trump_vs_musk.jpg"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/kontext-2025-07-01-profil-karin-kneissl/index.md
+++ b/apps/web/app/clanek/_articles/kontext-2025-07-01-profil-karin-kneissl/index.md
@@ -1,7 +1,8 @@
 ---
 title: "Tanec s Putinem: jak si bývalá rakouská ministryně zahraničí našla nový domov v Rusku"
 date: "2025-07-01"
-author: "Amanda Coakley, překlad Mahdalová & Škop"
+author: "Amanda Coakley"
+translator: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Karin Kneissl se dostala na titulní stránky po celém světě, když v roce 2018 pozvala ruského prezidenta na svou svatbu. O pět let později se přestěhovala do Petrohradu. Skandál odhalil temnou pravdu o vazbách mezi Vídní a Moskvou."
 coverImage: "images/kneissl-putin-tanec-profil-datatimes-guardian-rakousko-rusko.webp"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/kontext-2025-07-07-byl-zelenskyj-v-obleku-nebo-ne-otazka-za-3-miliardy/index.md
+++ b/apps/web/app/clanek/_articles/kontext-2025-07-07-byl-zelenskyj-v-obleku-nebo-ne-otazka-za-3-miliardy/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Byl Zelenskyj v obleku, nebo ne? Otázka za 3 miliardy!"
 date: "2025-07-07"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Na první pohled banální otázka: měl ukrajinský prezident Volodymyr Zelenskyj na summitu NATO ve dnech 24.–25. června 2025 na sobě oblek, nebo neměl? Ve skutečnosti se kolem této otázky roztočila sázková spirála, na jejímž konci leží v přepočtu více než tři miliardy korun.."
 coverImage: "images/main.webp"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/kontext-2025-08-29-volby-2025-skryte-koalice-podcast/index.md
+++ b/apps/web/app/clanek/_articles/kontext-2025-08-29-volby-2025-skryte-koalice-podcast/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Volby 2025: Skryté koalice - podcast"
 date: "2025-08-29"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Babiš má nyní 95% šanci, že bude sestavovat vládu. Ale s kým? Poslechněte si náš podcast."
 coverImage: "images/volby_2025-snemovna-skryte-koalice-podcast-mahdalova-skop1a.jpg"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/kontext-2025-10-15-turek-a-jeho-nevysvetlene-prijmy/index.md
+++ b/apps/web/app/clanek/_articles/kontext-2025-10-15-turek-a-jeho-nevysvetlene-prijmy/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Peníze odnikud: Stále nevysvětlené příjmy Filipa Turka"
 date: "2025-10-15"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Turek střídá verze o svých miliónových příjmech: jednou z firem, podruhé z 'freelancerských' konzultací. Účetnictví však vyplácení odměn majiteli neprokazuje a čísla nedávají ekonomický smysl."
 coverImage: "images/filip-turek-prijmy-nejasne-prijmy-mahdalova-skop.webp"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/mandaty-2024-10-31-ctyrkoalice-by-se-nad-vodou-drzela-jen-stezi/index.md
+++ b/apps/web/app/clanek/_articles/mandaty-2024-10-31-ctyrkoalice-by-se-nad-vodou-drzela-jen-stezi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Kdyby se dnes konaly volby, čtyřkoalice by se nad vodou držela jen stěží"
 date: "2024-10-31"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Naděje na získání většiny 101 mandátů jsou nyní pro čtyřčlennou koalici bez Pirátů (ODS, TOP 09, KDU-ČSL a STAN) mizivé."
 coverImage: "images/poll_tracker.png"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/mandaty-nemecky-volebni-model/index.md
+++ b/apps/web/app/clanek/_articles/mandaty-nemecky-volebni-model/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Německý volební model: Kdo má šanci usednout ve Spolkovém sněmu"
 date: "2025-01-19"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Od posledních všeobecných voleb zpracováváme všechny relevantní průzkumy a zaznamenáváme vývoj šancí jednotlivých politických stran."
 coverImage: "images/mandaty-nemecko-poll-of-polls-pruzkumy-2025.jpg"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/mandaty-unikatni-volebni-model/index.md
+++ b/apps/web/app/clanek/_articles/mandaty-unikatni-volebni-model/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Unikátní volební model: Kdo má šanci na křesla ve Sněmovně a kdo bude vládnout"
 date: "2025-02-18"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Stejně jako v předchozím volebním období, i nyní od posledních sněmovních voleb zpracováváme všechny relevantní průzkumy..."
 coverImage: "images/mandaty-cesko-poll-of-polls-pruzkumy-2025.jpg"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/volby-kanada-2025-04-29-jak-trump-vzkrisil-liberaly/index.md
+++ b/apps/web/app/clanek/_articles/volby-kanada-2025-04-29-jak-trump-vzkrisil-liberaly/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Jak Trump vzkřísil kanadské liberály"
 date: "2025-04-29"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Ještě na začátku roku 2025 to vypadalo jasně. Justin Trudeau byl na odpis, liberální strana ztrácela v průzkumech přes 20 bodů a konzervativci mířili k pohodlnému vítězství. A pak přišel Trump."
 coverImage: "images/kanada-volby-2025.jpg"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/volby-nemecko-2025-02-21-jak-se-voli/index.md
+++ b/apps/web/app/clanek/_articles/volby-nemecko-2025-02-21-jak-se-voli/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Německé volby: Jak se volí a jak správně číst výsledky"
 date: "2025-02-21"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "V neděli proběhnou německé parlamentní volby. Proč klasické volební mapy nejsou vždy nejlepší volbou a jak správně číst výsledky."
 coverImage: "images/step_13.svg"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/volby-nemecko-2025-02-27-vysledky/index.md
+++ b/apps/web/app/clanek/_articles/volby-nemecko-2025-02-27-vysledky/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Německé volby: Ostblok volil radikálně? Ne tak docela"
 date: "2025-02-27"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "V neděli se konaly německé parlamentní volby. Na první pohled se může zdát, že se někdejší Východní Německo zradikalizovalo, jenže to je dost zkreslený pohled."
 coverImage: "images/cartogram_germany_winner.png"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/volby-nemecko-2025-02-28-tiktokova-generace/index.md
+++ b/apps/web/app/clanek/_articles/volby-nemecko-2025-02-28-tiktokova-generace/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Německé volby: Radikální a rozdělená tiktoková generace"
 date: "2025-02-28"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Nejmladší “tiktoková” generace v německých volbách volila - shodně s Tiktokem."
 coverImage: "images/main.webp"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/volby-rakousko-2024-11-27-kartogramy/index.md
+++ b/apps/web/app/clanek/_articles/volby-rakousko-2024-11-27-kartogramy/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Naše kartogramy oceňují i v Rakousku"
 date: "2024-11-27"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Pochval a uznání není nikdy dost 😊⁣ Naše kartogramy si jako ukázkové vybrali nejvyšší statistici Rakouska."
 coverImage: "images/Rakousko-kartogramy.png"
 filter: ["kontext"]

--- a/apps/web/app/clanek/_articles/volby-rumunsko-2024-12-08-rumunsko-volby/index.md
+++ b/apps/web/app/clanek/_articles/volby-rumunsko-2024-12-08-rumunsko-volby/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Rumunsko: Krize demokracie u prezidentských voleb"
 date: "2024-12-08"  
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Anulování prezidentských voleb kvůli hybridnímu útoku odhaluje zranitelnost demokratických procesů."  
 coverImage: "images/Rumunsko-volby-zruseno-2024.png
 "

--- a/apps/web/app/clanek/_articles/volby-rumunsko-2024-12-20-rumunsko-volby-eu/index.md
+++ b/apps/web/app/clanek/_articles/volby-rumunsko-2024-12-20-rumunsko-volby-eu/index.md
@@ -2,7 +2,7 @@
 
 title: "Rumunsko v epicentru hybridní války. Stejně jako my"  
 date: "2024-12-20"  
-author: "Mahdalová & Škop"  
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Hybridní kampaně, manipulace algoritmů a vlivové operace ukazují, jak lze destabilizovat demokratické procesy."  
 coverImage: "images/main.webp"  
 filter: ["kontext"]  

--- a/apps/web/app/clanek/_articles/volby-usa-2024-11-05-predikce-ktera-se-vam-nebude-libit/index.md
+++ b/apps/web/app/clanek/_articles/volby-usa-2024-11-05-predikce-ktera-se-vam-nebude-libit/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Predikce, která se vám nebude líbit"
 date: "2024-11-05"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Čekáte těsné vítězství Trumpa či Harris? Vůbec to tak být nemusí. Ukážeme vám, že rozdíly mohou být mnohem větší a že to není chyba průzkumných agentur."
 coverImage: "images/USA_volby_predikce.png"
 filter: ["analýza"]

--- a/apps/web/app/clanek/_articles/volby-usa-2024-11-06-volby-vyhraje-trump-a-nebude-to-tesne/index.md
+++ b/apps/web/app/clanek/_articles/volby-usa-2024-11-06-volby-vyhraje-trump-a-nebude-to-tesne/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Volby vyhraje Trump a nebude to těsně"
 date: "2024-11-06"
-author: "Mahdalová & Škop"
+author: "Kateřina Mahdalová & Michal Škop"
 excerpt: "Naše predikce ukazuje s 80% jistotou, že příštím americkým prezidentem se stane Donald Trump."
 coverImage: "images/USA-volby-2024-predikce.png"
 filter: ["analýza"]

--- a/apps/web/components/clanek/ArticleRenderer.tsx
+++ b/apps/web/components/clanek/ArticleRenderer.tsx
@@ -1,10 +1,12 @@
 // components/clanek/ArticleRenderer.tsx
+
 'use client';
 
 import { Anchor, Paper, Title, Text, Container, Stack, useMantineTheme } from '@mantine/core';
 import { Global } from '@mantine/styles';
 import { useState, useEffect } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote';
 import type { MDXComponents } from 'mdx/types';
 import type { ImageProps } from 'next/image';
@@ -14,6 +16,7 @@ import { FlourishEmbed } from '@/components/mdx/FlourishEmbed';
 import ScrollyTelling from '@/components/common/ScrollyTelling';
 import { PartyFace } from '@/components/politics/PartyFace';
 import { MotionsStancesTable } from '@/components/politics/MotionsStancesTable';
+import { normalizeAuthor, splitAuthors } from '@/utils/authorUtils';
 // import yaml from 'js-yaml';
 
 interface ArticleProps {
@@ -21,6 +24,7 @@ interface ArticleProps {
   title?: string;
   date?: string;
   author?: string;
+  translator?: string;
   slug: string;
   scrollyContent?: any;     // Add scrollyContent to the ArticleProps
   backgroundColor?: string;  // Optional background color
@@ -33,6 +37,7 @@ export function ArticleRenderer({
   title,
   date,
   author,
+  translator,
   slug = '',
   scrollyContent,
   backgroundColor,
@@ -219,8 +224,47 @@ export function ArticleRenderer({
         )}
 
         {date && (
-          <Text size="sm" c={textColor || "dimmed"}>
-            {author ? `${author.toUpperCase()} • ` : ''}
+          <Text size="sm" c={textColor || 'dimmed'}>
+            {author ? (
+              <>
+                {splitAuthors(author).map((authorName, index, arr) => (
+                  <span key={`${authorName}-${index}`}>
+                    <Anchor
+                      component={Link}
+                      href={`/autor/${normalizeAuthor(authorName)}`}
+                      underline="hover"
+                      c={textColor || 'dimmed'}
+                    >
+                      {authorName.toUpperCase()}
+                    </Anchor>
+                    {index < arr.length - 1 ? ', ' : ''}
+                  </span>
+                ))}
+              </>
+            ) : null}
+
+            {(author || translator) ? ' • ' : ''}
+
+            {translator ? (
+              <>
+                {'PŘEKLAD: '}
+                {splitAuthors(translator).map((translatorName, index, arr) => (
+                  <span key={`${translatorName}-${index}`}>
+                    <Anchor
+                      component={Link}
+                      href={`/autor/${normalizeAuthor(translatorName)}`}
+                      underline="hover"
+                      c={textColor || 'dimmed'}
+                    >
+                      {translatorName.toUpperCase()}
+                    </Anchor>
+                    {index < arr.length - 1 ? ', ' : ''}
+                  </span>
+                ))}
+                {' • '}
+              </>
+            ) : null}
+
             {new Date(date).toLocaleDateString('cs-CZ')}
           </Text>
         )}

--- a/apps/web/lib/articles.ts
+++ b/apps/web/lib/articles.ts
@@ -68,6 +68,7 @@ export async function getArticleBySlug(directorySlug: string) {
     title: data.title || 'Untitled',
     date: data.date || '',
     author: data.author || 'Anonymous',
+    translator: data.translator || '',
     excerpt: data.excerpt || '',
     coverImage: data.coverImage || null,
   };

--- a/apps/web/utils/authorServerUtils.ts
+++ b/apps/web/utils/authorServerUtils.ts
@@ -1,0 +1,35 @@
+// utils/authorServerUtils.ts
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { normalizeAuthor, splitAuthors } from '@/utils/authorUtils';
+
+export async function getAllAuthors(): Promise<Map<string, string>> {
+  const articlesDirectory = path.join(process.cwd(), 'app/clanek/_articles');
+  const authorMap = new Map<string, string>();
+
+  try {
+    const articleFolders = fs.readdirSync(articlesDirectory);
+
+    articleFolders.forEach((folder) => {
+      const fullPath = path.join(articlesDirectory, folder, 'index.md');
+      if (!fs.existsSync(fullPath)) return;
+
+      const fileContents = fs.readFileSync(fullPath, 'utf8');
+      const { data } = matter(fileContents);
+
+      const authors = splitAuthors(data.author);
+      authors.forEach((name) => {
+        const normalized = normalizeAuthor(name);
+        if (!normalized) return;
+        if (!authorMap.has(normalized)) {
+          authorMap.set(normalized, name);
+        }
+      });
+    });
+  } catch (err) {
+    console.error('Error reading authors:', err);
+  }
+
+  return authorMap;
+}

--- a/apps/web/utils/authorUtils.ts
+++ b/apps/web/utils/authorUtils.ts
@@ -1,0 +1,31 @@
+// utils/authorUtils.ts
+export function normalizeAuthor(author: string): string {
+  return author
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function splitAuthors(author: unknown): string[] {
+  if (!author) return [];
+
+  if (Array.isArray(author)) {
+    return author
+      .filter((a): a is string => typeof a === 'string')
+      .map((a) => a.trim())
+      .filter(Boolean);
+  }
+
+  if (typeof author === 'string') {
+    return author
+      .split(/,|&|\s+and\s+|\s+a\s+/i)
+      .map((a) => a.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces author-centric navigation and metadata cleanup across both apps.
> 
> - New dynamic routes `app/autor/[slug]` (web) and `app/author/[slug]` (studio) list articles per author using `getAllAuthors`
> - Adds utilities `authorUtils` (normalize/split names) and `authorServerUtils` (scan articles) in both apps
> - Updates `ArticleRenderer` to render linked author names and optional `translator` (with links); `articles.ts` now returns `translator`
> - Standardizes frontmatter: replaces generic `author` with full names across many markdown articles; adds `translator` where applicable
> - 404 handling for unknown authors or authors without articles; static params generation for all authors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 655d08abeac52277b371c12ac93ccca1a4250a3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->