### PR TITLE
Feature/infobox mediabox 83

### DIFF
--- a/apps/datajournalism.studio/components/a/ArticleRenderer.tsx
+++ b/apps/datajournalism.studio/components/a/ArticleRenderer.tsx
@@ -9,6 +9,7 @@ import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote';
 import type { MDXComponents } from 'mdx/types';
 import type { ImageProps } from 'next/image';
 import { CodeBlock, MediaBox } from './MediaBox'; // Import the MediaBox component
+import { InfoBox } from './InfoBox'; // Import the InfoBox component
 import { FlourishEmbed } from '@/components/mdx/FlourishEmbed';
 import ScrollyTelling from '@/components/common/ScrollyTelling';
 import Timeline from '@/components/common/Timeline';
@@ -54,6 +55,7 @@ export function ArticleRenderer({
 
   const components: MDXComponents = {
     MediaBox, // Register MediaBox directly, allowing remarkBoxPlugin to handle box syntax
+    InfoBox,  // Register InfoBox for info/data boxes
     FlourishEmbed,
     code: CodeBlock,  // This handles the ```box syntax
 

--- a/apps/datajournalism.studio/components/a/InfoBox.tsx
+++ b/apps/datajournalism.studio/components/a/InfoBox.tsx
@@ -1,0 +1,47 @@
+// components/a/InfoBox.tsx
+import { Paper, useMantineTheme } from '@mantine/core';
+import React from 'react';
+import styles from './box.module.css';
+
+type InfoBoxType = 'info' | 'warning' | 'success' | 'error';
+
+interface InfoBoxProps {
+  children: React.ReactNode;
+  float?: 'right' | 'left' | 'none';
+  type?: InfoBoxType;
+}
+
+const typeStyles: Record<InfoBoxType, { borderColor: string; backgroundColor: string }> = {
+  info: { borderColor: '#6267a3', backgroundColor: '#f0f1f8' },
+  warning: { borderColor: '#f76800', backgroundColor: '#fff4eb' },
+  success: { borderColor: '#0f6c78', backgroundColor: '#e5f9fc' },
+  error: { borderColor: '#de1743', backgroundColor: '#fff4f6' },
+};
+
+export function InfoBox({ children, float, type = 'info' }: InfoBoxProps) {
+  const theme = useMantineTheme();
+  const boxStyles = typeStyles[type];
+
+  const floatClass =
+    float === 'right' ? styles.floatRight :
+    float === 'left'  ? styles.floatLeft  :
+    undefined;
+
+  return (
+    <Paper
+      shadow="xs"
+      px="md"
+      py="xs"
+      radius="md"
+      my="lg"
+      className={floatClass}
+      style={{
+        backgroundColor: boxStyles.backgroundColor,
+        borderLeft: `4px solid ${boxStyles.borderColor}`,
+        color: theme.colors.dark?.[7] ?? '#1a1a2e',
+      }}
+    >
+      {children}
+    </Paper>
+  );
+}

--- a/apps/datajournalism.studio/components/a/MediaBox.tsx
+++ b/apps/datajournalism.studio/components/a/MediaBox.tsx
@@ -1,87 +1,46 @@
 // components/a/MediaBox.tsx
 import { Paper, useMantineTheme, useMantineColorScheme } from '@mantine/core';
-import { Global } from '@mantine/styles';
-// import ReactMarkdown from 'react-markdown';
 import React from 'react';
 import { DetailedHTMLProps, HTMLAttributes } from 'react';
-// import rehypeRaw from 'rehype-raw';
+import styles from './box.module.css';
 
 interface MediaBoxProps {
-  children: string;
+  children: React.ReactNode;
+  float?: 'right' | 'left' | 'none';
 }
 
-export function MediaBox({ children }: MediaBoxProps) {
+export function MediaBox({ children, float }: MediaBoxProps) {
   const theme = useMantineTheme();
   const { colorScheme } = useMantineColorScheme();
 
-  // Function to convert markdown links in HTML content
-  const convertMarkdownLinks = (content: string) => {
-    // Convert markdown links [text](url) to HTML <a> tags
-    return content.replace(
-      /\[([^\]]+)\]\(([^)]+)\)/g,
-      '<a href="$2" target="_blank" rel="noopener noreferrer" class="box-content">$1</a>'
-    );
-  };
-
-  // Function to convert markdown headings to H3 tags
-  function convertMarkdownHeadersToH3(markdown: string): string {
-    // Remove <p> tags around headers and convert headers to <h3> tags
-    return markdown.replace(/<p>(#{1,6}\s+.*?)<\/p>/g, (match, p1) => {
-      return p1.replace(/^#{1,6}\s+(.*)$/gm, '<h3>$1</h3>');
-    });
-  }
-  
-
-  // Process the content
-  const processedContent = convertMarkdownLinks(convertMarkdownHeadersToH3(children));
+  const floatClass =
+    float === 'right' ? styles.floatRight :
+    float === 'left'  ? styles.floatLeft  :
+    undefined;
 
   return (
-    <>
-      <Global
-        styles={{
-          'a.box-content': {
-            color: theme.colors.brand[3],
-            textDecoration: 'none',
-            '&:hover': {
-              textDecoration: 'underline',
-            },
-            '&:active': {
-              color: theme.colors.brand[5],
-            },
-            '&:visited': {
-              color: theme.colors.brand[2],
-            },
-          },
-        }}
-      />
-      <Paper
-        shadow="xs"
-        px="md"
-        py="xs"
-        radius="md"
-        my="lg"
-        style={{
-          backgroundColor:
-            colorScheme === 'dark'
-              ? theme.colors.gray[8]
-              : theme.colors.brandNavy[6],
-          color: theme.colors.background[1],
-        }}
-      >
-        <div dangerouslySetInnerHTML={{ __html: processedContent }} />
-      </Paper>
-    </>
+    <Paper
+      shadow="xs"
+      px="md"
+      py="xs"
+      radius="md"
+      my="lg"
+      className={floatClass}
+      style={{
+        backgroundColor:
+          colorScheme === 'dark'
+            ? theme.colors.gray[8]
+            : theme.colors.brandNavy[6],
+        color: theme.colors.background[1],
+      }}
+    >
+      {children}
+    </Paper>
   );
 }
 
 type CodeBlockProps = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
 
 export function CodeBlock(props: CodeBlockProps): JSX.Element {
-  const { className, children } = props;
-
-  if (className === 'language-box') {
-    return <MediaBox>{String(children)}</MediaBox>;
-  }
-
   return <code {...props} />;
 }

--- a/apps/datajournalism.studio/components/a/box.module.css
+++ b/apps/datajournalism.studio/components/a/box.module.css
@@ -1,0 +1,26 @@
+.floatRight {
+  float: right;
+  width: 45%;
+  max-width: 400px;
+  margin-left: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.floatLeft {
+  float: left;
+  width: 45%;
+  max-width: 400px;
+  margin-right: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 768px) {
+  .floatRight,
+  .floatLeft {
+    float: none;
+    width: 100%;
+    max-width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+  }
+}

--- a/apps/datajournalism.studio/lib/articles.ts
+++ b/apps/datajournalism.studio/lib/articles.ts
@@ -5,6 +5,7 @@ import matter from 'gray-matter';
 import yaml from 'js-yaml';
 import { serialize } from 'next-mdx-remote/serialize';
 import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
 import { remarkBoxPlugin } from './remark-box-plugin'; // Your custom plugin
 import { remarkFlourishPlugin } from './remark-flourish-plugin';
 import type { ScrollyContent } from '@/types/scrolly';
@@ -64,6 +65,7 @@ export async function getArticleBySlug(directorySlug: string) {
     },
     mdxOptions: {
       remarkPlugins: [remarkGfm, remarkBoxPlugin, remarkFlourishPlugin],
+      rehypePlugins: [[rehypeRaw, { passThrough: ['mdxJsxFlowElement', 'mdxJsxTextElement', 'mdxFlowExpression', 'mdxTextExpression', 'mdxjsEsm'] }]],
     },
   });
 

--- a/apps/datajournalism.studio/lib/remark-box-plugin.js
+++ b/apps/datajournalism.studio/lib/remark-box-plugin.js
@@ -1,21 +1,53 @@
 // lib/remark-box-plugin.js
 import { visit } from 'unist-util-visit';
+import { remark } from 'remark';
+import remarkGfm from 'remark-gfm';
+
+// A small parser to turn box content into a proper markdown AST
+const markdownParser = remark().use(remarkGfm);
+
+// Parse optional props from the fence meta string, e.g. ```infobox warning right
+function parseMeta(meta) {
+  const str = meta || '';
+  const type = ['info', 'warning', 'success', 'error'].find(t => str.includes(t)) || 'info';
+  const float = ['right', 'left'].find(f => str.includes(f)) || null;
+  return { type, float };
+}
+
+function makeAttr(name, value) {
+  return { type: 'mdxJsxAttribute', name, value };
+}
 
 export function remarkBoxPlugin() {
   return (tree) => {
     visit(tree, 'code', (node, index, parent) => {
-      if (node.lang === 'box') {
-        // Split content by line breaks and wrap each line in <p> tags
-        const paragraphs = node.value
-          .split('\n')
-          .map(line => `<p>${line.trim()}</p>`)
-          .join('');
+      const lang = node.lang;
+      if (lang !== 'box' && lang !== 'mediabox' && lang !== 'infobox') return;
 
-        // Replace the node with an mdxJsxFlowElement for MediaBox
+      // Parse the box content as full markdown so links, headings, etc. work
+      const parsed = markdownParser.parse(node.value);
+
+      if (lang === 'infobox') {
+        const { type, float } = parseMeta(node.meta);
+        const attributes = [makeAttr('type', type)];
+        if (float) attributes.push(makeAttr('float', float));
+
+        parent.children[index] = {
+          type: 'mdxJsxFlowElement',
+          name: 'InfoBox',
+          attributes,
+          children: parsed.children,
+        };
+      } else {
+        // 'box' and 'mediabox' both map to MediaBox
+        const { float } = parseMeta(node.meta);
+        const attributes = float ? [makeAttr('float', float)] : [];
+
         parent.children[index] = {
           type: 'mdxJsxFlowElement',
           name: 'MediaBox',
-          children: [{ type: 'text', value: paragraphs }],
+          attributes,
+          children: parsed.children,
         };
       }
     });

--- a/apps/web/app/clanek/_articles/zzz-demo-article-features/index.md
+++ b/apps/web/app/clanek/_articles/zzz-demo-article-features/index.md
@@ -1,0 +1,350 @@
+---
+title: "Article features: quick reference"
+date: "9999-12-31"
+author: "Tech Team"
+excerpt: "Quick-reference guide for every feature available when writing articles: markdown, boxes, embeds, components, and more."
+tags: ["guide", "reference", "demo"]
+promoted: 0
+---
+
+This article is a **living quick-reference** for writing articles. Every feature is shown with the exact syntax you need to copy-paste, followed by a live rendered example.
+
+> **Note:** This article is dated far in the future (9999-12-31) so it never appears in article lists or on the front page. Linked from: [ScrollyTelling demo](/clanek/zzz-demo-scrollytelling-v1).
+
+---
+
+## 1. Basic markdown
+
+Standard GFM markdown works everywhere in articles.
+
+```md
+**bold**, _italic_, ~~strikethrough~~
+
+[Link text](https://example.com)
+
+- unordered list
+- second item
+  - nested item
+
+1. ordered list
+2. second item
+
+> Blockquote text
+```
+
+**bold**, _italic_, ~~strikethrough~~
+
+[Link text](https://www.mahdalova-skop.cz)
+
+- unordered list
+- second item
+  - nested item
+
+1. ordered list
+2. second item
+
+> Blockquote text
+
+---
+
+## 2. Tables
+
+Standard GFM pipe tables. Alignment via `:---`, `:---:`, `---:`.
+
+```md
+| Strana  | Hlasy | Mandáty |
+|---------|------:|:-------:|
+| ANO     | 27 %  | 105     |
+| SPOLU   | 21 %  |  82     |
+| Piráti  |  8 %  |  22     |
+```
+
+| Strana  | Hlasy | Mandáty |
+|---------|------:|:-------:|
+| ANO     | 27 %  | 105     |
+| SPOLU   | 21 %  |  82     |
+| Piráti  |  8 %  |  22     |
+
+---
+
+## 3. Images
+
+Images are served from the `images/` subfolder of the article directory. No full path needed.
+
+```md
+![Alt text](images/my-image.webp)
+```
+
+For an image with a caption, follow it with an italic line:
+
+```md
+![Chart showing results](images/chart.png)
+_Caption text goes here._
+```
+
+---
+
+## 4. MediaBox — dark quote/source box
+
+Use for **quoted text from external sources**, short context notes, or embeds. Maps to the dark navy box.
+
+Three equivalent fence names — all produce the same result:
+
+````md
+```box
+Quoted text here. [Source link](https://example.com)
+```
+````
+
+````md
+```mediabox
+Same as box. Supports **markdown**, links, and headings.
+```
+````
+
+With float:
+
+````md
+```mediabox right
+This box floats right on desktop,
+full width on mobile.
+```
+````
+
+**Live example:**
+
+```box
+Hospodářské noviny (22. 7. 2024)
+
+Turek o svých příjmech říká, že jsou to zatím jen odhady.
+[Celý článek](https://archiv.hn.cz/c7-67344090-1320cc-393457007bcff0e)
+```
+
+---
+
+## 5. InfoBox — light callout box
+
+Use for **contextual data, tables, definitions, or callout notes**. Light background with a coloured left border.
+
+````md
+```infobox
+Basic info box (type defaults to "info").
+```
+````
+
+**Types:** `info` (default), `warning`, `success`, `error`
+
+**Float:** add `right` or `left` after the type (or alone)
+
+````md
+```infobox warning
+⚠️ This will not work without the YAML file.
+```
+````
+
+````md
+```infobox right
+Floats right on desktop, full width on mobile.
+
+| Rok  | Účast |
+|------|-------|
+| 2021 | 65 %  |
+| 2025 | 72 %  |
+```
+````
+
+**Live examples:**
+
+```infobox info
+**Info** — default type. Use for neutral context, methodology notes, or definitions.
+```
+
+```infobox warning
+**Warning** — use for caveats, data limitations, or important notes for the reader.
+```
+
+```infobox success
+**Success** — use for confirmed facts, corrections, or positive outcomes.
+```
+
+```infobox error
+**Error** — use for known issues or debunked claims.
+```
+
+```infobox right
+### Floated infobox
+
+| Rok  | Účast |
+|------|-------|
+| 2021 | 65 %  |
+| 2025 | 72 %  |
+
+This box floats right on desktop. Content wraps around it.
+```
+
+On mobile all floated boxes collapse to full width automatically.
+
+---
+
+## 6. Raw iframe embed
+
+Paste Flourish, Datawrapper, or any other embed code directly.
+
+```md
+<iframe
+  src="https://flo.uri.sh/visualisation/20114452/embed"
+  width="100%"
+  height="400"
+  frameBorder="0"
+  scrolling="no"
+></iframe>
+```
+
+**Live example:**
+
+<iframe src="https://flo.uri.sh/visualisation/20114452/embed" width="100%" height="400" frameBorder="0" scrolling="no"></iframe>
+
+Iframes also work **inside boxes**:
+
+````md
+```mediabox
+<iframe src="https://flo.uri.sh/visualisation/20114452/embed"
+  width="100%" height="300" frameBorder="0"></iframe>
+```
+````
+
+---
+
+## 7. FlourishEmbed component
+
+Alternative to raw iframes for Flourish. Loads the Flourish embed script automatically. Use `dataSrc` — the part after `flourish.studio/` in the chart URL.
+
+```md
+<FlourishEmbed dataSrc="visualisation/20114452" />
+```
+
+**Live example:**
+
+<FlourishEmbed dataSrc="visualisation/20114452" />
+
+---
+
+## 8. PartyFace
+
+Inline coloured badge for Czech and European Parliament parties. Use directly in running text.
+
+```md
+<PartyFace party="ANO" size={15} text="" /> ANO is the largest party.
+
+<PartyFace party="ANO" size={30} /> with default label
+```
+
+**Available parties:** `ANO`, `SPD`, `Piráti`, `SPOLU`, `ODS`, `STAN`, `KDU`, `KSČM`, `TOP09`, `Motoristé`
+
+**Props:**
+
+| Prop | Default | Notes |
+|------|---------|-------|
+| `party` | — | preset name, sets colour + label |
+| `size` | `42` | px, controls badge size |
+| `text` | preset label | override display text; `""` for icon only |
+| `color` | — | custom hex, if no `party` preset |
+
+**Live examples:**
+
+<PartyFace party="ANO" size={30} /> <PartyFace party="SPD" size={30} /> <PartyFace party="Piráti" size={30} /> <PartyFace party="SPOLU" size={30} /> <PartyFace party="ODS" size={30} /> <PartyFace party="STAN" size={30} /> <PartyFace party="KDU" size={30} /> <PartyFace party="KSČM" size={30} /> <PartyFace party="TOP09" size={30} /> <PartyFace party="Motoristé" size={30} />
+
+Using `text=""` gives icon-only badges for inline use:
+
+<PartyFace party="ANO" size={15} text="" /> ANO supports the measure, while <PartyFace party="Piráti" size={15} text="" /> Piráti oppose it.
+
+---
+
+## 9. Timeline
+
+Filterable vertical timeline driven by a YAML file in the article directory.
+
+```md
+<Timeline yamlFile="timeline.yaml" />
+```
+
+**YAML structure:**
+
+```yaml
+title: "Timeline title"
+subtitle: "Optional subtitle"
+collapsedYears: [2024]       # years collapsed by default
+
+facetGroups:                 # optional filter groups
+  - key: topic
+    label: "Topic"
+    values:
+      - key: projects
+        label: "Projects"
+        color: "brandTeal.3"  # theme colour or hex
+        flag: "cz"            # optional: country flag code
+
+events:
+  - year: 2025
+    month: 6
+    facets:
+      topic: projects
+    date: "June 2025"        # display string
+    title: "Event title"
+    emoji: "📊"
+    summary: "One-line summary shown in collapsed view."
+    description: "Full text shown on expand."
+    persons:
+      - name: "Person Name"
+        bio: "Short bio"
+    link: "https://example.com"
+    linkText: "Link label"
+    tags: ["🆕 Tag"]
+```
+
+**Live example** (shows features added to this codebase):
+
+<Timeline yamlFile="timeline.yaml" />
+
+---
+
+## 10. ScrollyTelling
+
+Scroll-driven narrative with images and iframes. Requires a separate `scrollytelling.yaml` file.
+
+```md
+<ScrollyTelling yamlFile="scrollytelling.yaml" />
+```
+
+See the full guide with a live demo: [zzz-demo-scrollytelling-v1](/clanek/zzz-demo-scrollytelling-v1)
+
+---
+
+## 11. Raw HTML file (htmlInclude)
+
+For complex interactive pieces (custom JS, CSS, D3, etc.) that cannot be expressed in MDX. The HTML file is loaded from the article directory and injected before the MDX content.
+
+Set in frontmatter:
+
+```yaml
+---
+htmlInclude: "my-interactive.html"
+---
+```
+
+The HTML file can include `<style>` and `<script>` tags. Asset paths (images, data files) in the HTML are automatically rewritten relative to the article directory.
+
+---
+
+## Feature summary
+
+| Feature | Syntax | Import needed? |
+|---------|--------|:---:|
+| MediaBox | ` ```box ` / ` ```mediabox ` | No |
+| InfoBox | ` ```infobox ` | No |
+| Raw iframe | `<iframe ...>` | No |
+| FlourishEmbed | `<FlourishEmbed dataSrc="..." />` | No |
+| PartyFace | `<PartyFace party="..." />` | No |
+| Timeline | `<Timeline yamlFile="..." />` | No |
+| ScrollyTelling | `<ScrollyTelling yamlFile="..." />` | No |
+| Raw HTML | `htmlInclude:` in frontmatter | No |

--- a/apps/web/app/clanek/_articles/zzz-demo-article-features/index.md
+++ b/apps/web/app/clanek/_articles/zzz-demo-article-features/index.md
@@ -345,6 +345,6 @@ The HTML file can include `<style>` and `<script>` tags. Asset paths (images, da
 | Raw iframe | `<iframe ...>` | No |
 | FlourishEmbed | `<FlourishEmbed dataSrc="..." />` | No |
 | PartyFace | `<PartyFace party="..." />` | No |
-| Timeline | `<Timeline yamlFile="..." />` | No |
-| ScrollyTelling | `<ScrollyTelling yamlFile="..." />` | No |
+| Timeline | `<Timeline yamlFile="timeline.yaml" />` | No |
+| ScrollyTelling | `<ScrollyTelling yamlFile="scrollytelling.yaml" />` | No |
 | Raw HTML | `htmlInclude:` in frontmatter | No |

--- a/apps/web/app/clanek/_articles/zzz-demo-article-features/timeline.yaml
+++ b/apps/web/app/clanek/_articles/zzz-demo-article-features/timeline.yaml
@@ -1,0 +1,79 @@
+title: "Article features history"
+subtitle: "When each feature was added"
+
+facetGroups:
+  - key: type
+    label: "Type"
+    values:
+      - key: component
+        label: "Component"
+        color: "brandRoyalBlue.4"
+      - key: layout
+        label: "Layout"
+        color: "brandTeal.3"
+      - key: embed
+        label: "Embed"
+        color: "brandOrange.6"
+
+events:
+  - year: 2024
+    month: 1
+    facets:
+      type: component
+    date: "Early 2024"
+    title: "MediaBox (```box)"
+    emoji: "📦"
+    summary: "Dark navy box for quoted text and source citations."
+    description: "The original box component. Use ```box fences in markdown — no import needed."
+
+  - year: 2024
+    month: 6
+    facets:
+      type: embed
+    date: "Mid 2024"
+    title: "FlourishEmbed"
+    emoji: "📊"
+    summary: "Flourish chart component via data-src attribute."
+    description: "Use <FlourishEmbed dataSrc=\"visualisation/XXXXX\" /> to embed Flourish charts without an iframe."
+
+  - year: 2024
+    month: 9
+    facets:
+      type: component
+    date: "Late 2024"
+    title: "ScrollyTelling"
+    emoji: "📜"
+    summary: "Scroll-driven storytelling with images and iframes."
+    description: "Requires scrollytelling.yaml in the article directory. See zzz-demo-scrollytelling-v1 for a full guide."
+    link: "/clanek/zzz-demo-scrollytelling-v1"
+    linkText: "ScrollyTelling demo"
+
+  - year: 2025
+    month: 1
+    facets:
+      type: component
+    date: "Early 2025"
+    title: "PartyFace"
+    emoji: "🏷️"
+    summary: "Inline party badge icons for Czech/European political parties."
+    description: "Use <PartyFace party=\"ANO\" /> inline in text. Supports ANO, SPD, Piráti, SPOLU, ODS, STAN, KDU, TOP09, Motoristé."
+
+  - year: 2025
+    month: 6
+    facets:
+      type: component
+    date: "Mid 2025"
+    title: "Timeline"
+    emoji: "🗂️"
+    summary: "Filterable vertical timeline driven by a YAML file."
+    description: "Requires a .yaml file in the article directory. Supports facet filters, flags, person bios, and links."
+
+  - year: 2026
+    month: 2
+    facets:
+      type: layout
+    date: "February 2026"
+    title: "InfoBox (```infobox)"
+    emoji: "ℹ️"
+    summary: "Light-background info box with type and float support."
+    description: "Use ```infobox, ```infobox warning, ```infobox right etc. Types: info, warning, success, error. No import needed."

--- a/apps/web/components/clanek/ArticleRenderer.tsx
+++ b/apps/web/components/clanek/ArticleRenderer.tsx
@@ -11,6 +11,7 @@ import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote';
 import type { MDXComponents } from 'mdx/types';
 import type { ImageProps } from 'next/image';
 import { CodeBlock, MediaBox } from './MediaBox'; // Import the MediaBox component
+import { InfoBox } from './InfoBox'; // Import the InfoBox component
 import { TestComponent } from '@/components/mdx/TestComponent';
 import { FlourishEmbed } from '@/components/mdx/FlourishEmbed';
 import ScrollyTelling from '@/components/common/ScrollyTelling';
@@ -63,6 +64,7 @@ export function ArticleRenderer({
 
   const components: MDXComponents = {
     MediaBox, // Register MediaBox directly, allowing remarkBoxPlugin to handle box syntax
+    InfoBox,  // Register InfoBox for info/data boxes
     TestComponent,
     FlourishEmbed,
     PartyFace,

--- a/apps/web/components/clanek/InfoBox.tsx
+++ b/apps/web/components/clanek/InfoBox.tsx
@@ -1,6 +1,7 @@
 // components/clanek/InfoBox.tsx
 import { Paper, useMantineTheme } from '@mantine/core';
 import React from 'react';
+import styles from './box.module.css';
 
 type InfoBoxType = 'info' | 'warning' | 'success' | 'error';
 
@@ -19,14 +20,12 @@ const typeStyles: Record<InfoBoxType, { borderColor: string; backgroundColor: st
 
 export function InfoBox({ children, float, type = 'info' }: InfoBoxProps) {
   const theme = useMantineTheme();
-  const styles = typeStyles[type];
+  const boxStyles = typeStyles[type];
 
-  const floatStyle: React.CSSProperties =
-    float === 'right'
-      ? { float: 'right', width: '45%', maxWidth: '400px', marginLeft: '1.5rem', marginBottom: '1rem' }
-      : float === 'left'
-      ? { float: 'left', width: '45%', maxWidth: '400px', marginRight: '1.5rem', marginBottom: '1rem' }
-      : {};
+  const floatClass =
+    float === 'right' ? styles.floatRight :
+    float === 'left'  ? styles.floatLeft  :
+    undefined;
 
   return (
     <Paper
@@ -35,11 +34,11 @@ export function InfoBox({ children, float, type = 'info' }: InfoBoxProps) {
       py="xs"
       radius="md"
       my="lg"
+      className={floatClass}
       style={{
-        backgroundColor: styles.backgroundColor,
-        borderLeft: `4px solid ${styles.borderColor}`,
+        backgroundColor: boxStyles.backgroundColor,
+        borderLeft: `4px solid ${boxStyles.borderColor}`,
         color: theme.colors.dark?.[7] ?? '#1a1a2e',
-        ...floatStyle,
       }}
     >
       {children}

--- a/apps/web/components/clanek/InfoBox.tsx
+++ b/apps/web/components/clanek/InfoBox.tsx
@@ -1,0 +1,48 @@
+// components/clanek/InfoBox.tsx
+import { Paper, useMantineTheme } from '@mantine/core';
+import React from 'react';
+
+type InfoBoxType = 'info' | 'warning' | 'success' | 'error';
+
+interface InfoBoxProps {
+  children: React.ReactNode;
+  float?: 'right' | 'left' | 'none';
+  type?: InfoBoxType;
+}
+
+const typeStyles: Record<InfoBoxType, { borderColor: string; backgroundColor: string }> = {
+  info: { borderColor: '#6267a3', backgroundColor: '#f0f1f8' },
+  warning: { borderColor: '#f76800', backgroundColor: '#fff4eb' },
+  success: { borderColor: '#0f6c78', backgroundColor: '#e5f9fc' },
+  error: { borderColor: '#de1743', backgroundColor: '#fff4f6' },
+};
+
+export function InfoBox({ children, float, type = 'info' }: InfoBoxProps) {
+  const theme = useMantineTheme();
+  const styles = typeStyles[type];
+
+  const floatStyle: React.CSSProperties =
+    float === 'right'
+      ? { float: 'right', width: '45%', maxWidth: '400px', marginLeft: '1.5rem', marginBottom: '1rem' }
+      : float === 'left'
+      ? { float: 'left', width: '45%', maxWidth: '400px', marginRight: '1.5rem', marginBottom: '1rem' }
+      : {};
+
+  return (
+    <Paper
+      shadow="xs"
+      px="md"
+      py="xs"
+      radius="md"
+      my="lg"
+      style={{
+        backgroundColor: styles.backgroundColor,
+        borderLeft: `4px solid ${styles.borderColor}`,
+        color: theme.colors.dark?.[7] ?? '#1a1a2e',
+        ...floatStyle,
+      }}
+    >
+      {children}
+    </Paper>
+  );
+}

--- a/apps/web/components/clanek/MediaBox.tsx
+++ b/apps/web/components/clanek/MediaBox.tsx
@@ -1,10 +1,7 @@
 // components/clanek/MediaBox.tsx
 import { Paper, useMantineTheme, useMantineColorScheme } from '@mantine/core';
-// import { Global } from '@mantine/styles';
-// import ReactMarkdown from 'react-markdown';
 import React from 'react';
 import { DetailedHTMLProps, HTMLAttributes } from 'react';
-// import rehypeRaw from 'rehype-raw';
 
 interface MediaBoxProps {
   children: React.ReactNode;
@@ -43,58 +40,8 @@ export function MediaBox({ children, float }: MediaBoxProps) {
   );
 }
 
-// Legacy string-based MediaBox used by CodeBlock (```box syntax)
-interface LegacyMediaBoxProps {
-  children: string;
-}
-
-function LegacyMediaBox({ children }: LegacyMediaBoxProps) {
-  const theme = useMantineTheme();
-  const { colorScheme } = useMantineColorScheme();
-
-  const convertMarkdownLinks = (content: string) => {
-    return content.replace(
-      /\[([^\]]+)\]\(([^)]+)\)/g,
-      '<a href="$2" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:underline;">$1</a>'
-    );
-  };
-
-  function convertMarkdownHeadersToH3(markdown: string): string {
-    return markdown.replace(/<p>(#{1,6}\s+.*?)<\/p>/g, (match, p1) => {
-      return p1.replace(/^#{1,6}\s+(.*)$/gm, '<h3>$1</h3>');
-    });
-  }
-
-  const processedContent = convertMarkdownLinks(convertMarkdownHeadersToH3(children));
-
-  return (
-    <Paper
-      shadow="xs"
-      px="md"
-      py="xs"
-      radius="md"
-      my="lg"
-      style={{
-        backgroundColor:
-          colorScheme === 'dark'
-            ? theme.colors.gray[8]
-            : theme.colors.brandNavy[6],
-        color: theme.colors.background[1],
-      }}
-    >
-      <div dangerouslySetInnerHTML={{ __html: processedContent }} />
-    </Paper>
-  );
-}
-
 type CodeBlockProps = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
 
 export function CodeBlock(props: CodeBlockProps): JSX.Element {
-  const { className, children } = props;
-
-  if (className === 'language-box') {
-    return <LegacyMediaBox>{String(children)}</LegacyMediaBox>;
-  }
-
   return <code {...props} />;
 }

--- a/apps/web/components/clanek/MediaBox.tsx
+++ b/apps/web/components/clanek/MediaBox.tsx
@@ -1,76 +1,89 @@
 // components/clanek/MediaBox.tsx
 import { Paper, useMantineTheme, useMantineColorScheme } from '@mantine/core';
-import { Global } from '@mantine/styles';
+// import { Global } from '@mantine/styles';
 // import ReactMarkdown from 'react-markdown';
 import React from 'react';
 import { DetailedHTMLProps, HTMLAttributes } from 'react';
 // import rehypeRaw from 'rehype-raw';
 
 interface MediaBoxProps {
-  children: string;
+  children: React.ReactNode;
+  float?: 'right' | 'left' | 'none';
 }
 
-export function MediaBox({ children }: MediaBoxProps) {
+export function MediaBox({ children, float }: MediaBoxProps) {
   const theme = useMantineTheme();
   const { colorScheme } = useMantineColorScheme();
 
-  // Function to convert markdown links in HTML content
+  const floatStyle: React.CSSProperties =
+    float === 'right'
+      ? { float: 'right', width: '45%', maxWidth: '400px', marginLeft: '1.5rem', marginBottom: '1rem' }
+      : float === 'left'
+      ? { float: 'left', width: '45%', maxWidth: '400px', marginRight: '1.5rem', marginBottom: '1rem' }
+      : {};
+
+  return (
+    <Paper
+      shadow="xs"
+      px="md"
+      py="xs"
+      radius="md"
+      my="lg"
+      style={{
+        backgroundColor:
+          colorScheme === 'dark'
+            ? theme.colors.gray[8]
+            : theme.colors.brandNavy[6],
+        color: theme.colors.background[1],
+        ...floatStyle,
+      }}
+    >
+      {children}
+    </Paper>
+  );
+}
+
+// Legacy string-based MediaBox used by CodeBlock (```box syntax)
+interface LegacyMediaBoxProps {
+  children: string;
+}
+
+function LegacyMediaBox({ children }: LegacyMediaBoxProps) {
+  const theme = useMantineTheme();
+  const { colorScheme } = useMantineColorScheme();
+
   const convertMarkdownLinks = (content: string) => {
-    // Convert markdown links [text](url) to HTML <a> tags
     return content.replace(
       /\[([^\]]+)\]\(([^)]+)\)/g,
-      '<a href="$2" target="_blank" rel="noopener noreferrer" class="box-content">$1</a>'
+      '<a href="$2" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:underline;">$1</a>'
     );
   };
 
-  // Function to convert markdown headings to H3 tags
   function convertMarkdownHeadersToH3(markdown: string): string {
-    // Remove <p> tags around headers and convert headers to <h3> tags
     return markdown.replace(/<p>(#{1,6}\s+.*?)<\/p>/g, (match, p1) => {
       return p1.replace(/^#{1,6}\s+(.*)$/gm, '<h3>$1</h3>');
     });
   }
-  
 
-  // Process the content
   const processedContent = convertMarkdownLinks(convertMarkdownHeadersToH3(children));
 
   return (
-    <>
-      <Global
-        styles={{
-          'a.box-content': {
-            color: theme.colors.brand[3],
-            textDecoration: 'none',
-            '&:hover': {
-              textDecoration: 'underline',
-            },
-            '&:active': {
-              color: theme.colors.brand[5],
-            },
-            '&:visited': {
-              color: theme.colors.brand[2],
-            },
-          },
-        }}
-      />
-      <Paper
-        shadow="xs"
-        px="md"
-        py="xs"
-        radius="md"
-        my="lg"
-        style={{
-          backgroundColor:
-            colorScheme === 'dark'
-              ? theme.colors.gray[8]
-              : theme.colors.brandNavy[6],
-          color: theme.colors.background[1],
-        }}
-      >
-        <div dangerouslySetInnerHTML={{ __html: processedContent }} />
-      </Paper>
-    </>
+    <Paper
+      shadow="xs"
+      px="md"
+      py="xs"
+      radius="md"
+      my="lg"
+      style={{
+        backgroundColor:
+          colorScheme === 'dark'
+            ? theme.colors.gray[8]
+            : theme.colors.brandNavy[6],
+        color: theme.colors.background[1],
+      }}
+    >
+      <div dangerouslySetInnerHTML={{ __html: processedContent }} />
+    </Paper>
   );
 }
 
@@ -80,7 +93,7 @@ export function CodeBlock(props: CodeBlockProps): JSX.Element {
   const { className, children } = props;
 
   if (className === 'language-box') {
-    return <MediaBox>{String(children)}</MediaBox>;
+    return <LegacyMediaBox>{String(children)}</LegacyMediaBox>;
   }
 
   return <code {...props} />;

--- a/apps/web/components/clanek/MediaBox.tsx
+++ b/apps/web/components/clanek/MediaBox.tsx
@@ -2,6 +2,7 @@
 import { Paper, useMantineTheme, useMantineColorScheme } from '@mantine/core';
 import React from 'react';
 import { DetailedHTMLProps, HTMLAttributes } from 'react';
+import styles from './box.module.css';
 
 interface MediaBoxProps {
   children: React.ReactNode;
@@ -12,12 +13,10 @@ export function MediaBox({ children, float }: MediaBoxProps) {
   const theme = useMantineTheme();
   const { colorScheme } = useMantineColorScheme();
 
-  const floatStyle: React.CSSProperties =
-    float === 'right'
-      ? { float: 'right', width: '45%', maxWidth: '400px', marginLeft: '1.5rem', marginBottom: '1rem' }
-      : float === 'left'
-      ? { float: 'left', width: '45%', maxWidth: '400px', marginRight: '1.5rem', marginBottom: '1rem' }
-      : {};
+  const floatClass =
+    float === 'right' ? styles.floatRight :
+    float === 'left'  ? styles.floatLeft  :
+    undefined;
 
   return (
     <Paper
@@ -26,13 +25,13 @@ export function MediaBox({ children, float }: MediaBoxProps) {
       py="xs"
       radius="md"
       my="lg"
+      className={floatClass}
       style={{
         backgroundColor:
           colorScheme === 'dark'
             ? theme.colors.gray[8]
             : theme.colors.brandNavy[6],
         color: theme.colors.background[1],
-        ...floatStyle,
       }}
     >
       {children}

--- a/apps/web/components/clanek/box.module.css
+++ b/apps/web/components/clanek/box.module.css
@@ -1,0 +1,26 @@
+.floatRight {
+  float: right;
+  width: 45%;
+  max-width: 400px;
+  margin-left: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.floatLeft {
+  float: left;
+  width: 45%;
+  max-width: 400px;
+  margin-right: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 768px) {
+  .floatRight,
+  .floatLeft {
+    float: none;
+    width: 100%;
+    max-width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+  }
+}

--- a/apps/web/lib/articles.ts
+++ b/apps/web/lib/articles.ts
@@ -5,6 +5,7 @@ import matter from 'gray-matter';
 import yaml from 'js-yaml';
 import { serialize } from 'next-mdx-remote/serialize';
 import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
 import { remarkBoxPlugin } from './remark-box-plugin';
 import { remarkFlourishPlugin } from './remark-flourish-plugin';
 import type { ScrollyContent } from '@/types/scrolly';
@@ -83,6 +84,7 @@ export async function getArticleBySlug(directorySlug: string) {
     },
     mdxOptions: {
       remarkPlugins: [remarkGfm, remarkBoxPlugin, remarkFlourishPlugin],
+      rehypePlugins: [rehypeRaw],
     },
   });
 

--- a/apps/web/lib/articles.ts
+++ b/apps/web/lib/articles.ts
@@ -84,7 +84,7 @@ export async function getArticleBySlug(directorySlug: string) {
     },
     mdxOptions: {
       remarkPlugins: [remarkGfm, remarkBoxPlugin, remarkFlourishPlugin],
-      rehypePlugins: [rehypeRaw],
+      rehypePlugins: [[rehypeRaw, { passThrough: ['mdxJsxFlowElement', 'mdxJsxTextElement', 'mdxFlowExpression', 'mdxTextExpression', 'mdxjsEsm'] }]],
     },
   });
 

--- a/apps/web/lib/remark-box-plugin.js
+++ b/apps/web/lib/remark-box-plugin.js
@@ -5,17 +5,22 @@ export function remarkBoxPlugin() {
   return (tree) => {
     visit(tree, 'code', (node, index, parent) => {
       if (node.lang === 'box') {
-        // Split content by line breaks and wrap each line in <p> tags
-        const paragraphs = node.value
+        // Convert each non-empty line into a proper paragraph AST node
+        // so MDX renders them as React elements (not raw HTML strings)
+        const children = node.value
           .split('\n')
-          .map(line => `<p>${line.trim()}</p>`)
-          .join('');
+          .filter(line => line.trim())
+          .map(line => ({
+            type: 'paragraph',
+            children: [{ type: 'text', value: line.trim() }],
+          }));
 
-        // Replace the node with an mdxJsxFlowElement for MediaBox
+        // Replace the code node with an mdxJsxFlowElement for MediaBox
         parent.children[index] = {
           type: 'mdxJsxFlowElement',
           name: 'MediaBox',
-          children: [{ type: 'text', value: paragraphs }],
+          attributes: [],
+          children,
         };
       }
     });

--- a/apps/web/lib/remark-box-plugin.js
+++ b/apps/web/lib/remark-box-plugin.js
@@ -6,17 +6,47 @@ import remarkGfm from 'remark-gfm';
 // A small parser to turn box content into a proper markdown AST
 const markdownParser = remark().use(remarkGfm);
 
+// Parse optional props from the fence meta string, e.g. ```infobox warning right
+function parseMeta(meta) {
+  const str = meta || '';
+  const type = ['info', 'warning', 'success', 'error'].find(t => str.includes(t)) || 'info';
+  const float = ['right', 'left'].find(f => str.includes(f)) || null;
+  return { type, float };
+}
+
+function makeAttr(name, value) {
+  return { type: 'mdxJsxAttribute', name, value };
+}
+
 export function remarkBoxPlugin() {
   return (tree) => {
     visit(tree, 'code', (node, index, parent) => {
-      if (node.lang === 'box') {
-        // Parse the box content as full markdown so links, headings, etc. work
-        const parsed = markdownParser.parse(node.value);
+      const lang = node.lang;
+      if (lang !== 'box' && lang !== 'mediabox' && lang !== 'infobox') return;
+
+      // Parse the box content as full markdown so links, headings, etc. work
+      const parsed = markdownParser.parse(node.value);
+
+      if (lang === 'infobox') {
+        const { type, float } = parseMeta(node.meta);
+        const attributes = [makeAttr('type', type)];
+        if (float) attributes.push(makeAttr('float', float));
+
+        parent.children[index] = {
+          type: 'mdxJsxFlowElement',
+          name: 'InfoBox',
+          attributes,
+          children: parsed.children,
+        };
+      } else {
+        // 'box' and 'mediabox' both map to MediaBox
+        const { float } = parseMeta(node.meta);
+        const attributes = float ? [makeAttr('float', float)] : [];
 
         parent.children[index] = {
           type: 'mdxJsxFlowElement',
           name: 'MediaBox',
-          attributes: [],
+          attributes,
           children: parsed.children,
         };
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Enables raw HTML rendering in MDX via `rehype-raw`, which increases XSS risk if article content is not fully trusted. Also changes how fenced box content is parsed/rendered, which could subtly affect existing article formatting.
> 
> **Overview**
> Adds a new light callout `InfoBox` (with `info`/`warning`/`success`/`error` variants) and registers it in both article renderers so authors can use ` ```infobox ... ``` ` fences in MDX.
> 
> Reworks box rendering to parse fenced content as real markdown AST (instead of injecting processed HTML), adds optional left/right float styling for both `MediaBox` and `InfoBox`, and extends the remark plugin to support ` ```box `, ` ```mediabox `, and ` ```infobox ` with meta-driven props.
> 
> Updates MDX serialization to allow raw HTML/iframes in articles via `rehype-raw`, and adds a new demo “article features” reference article (plus `timeline.yaml`) showcasing the syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39faef4f9e257bf4e3b300d4ccefeb800fc92378. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->