### PR TITLE
Add RelatedArticles component

### DIFF
--- a/apps/datajournalism.studio/components/a/ArticleRenderer.tsx
+++ b/apps/datajournalism.studio/components/a/ArticleRenderer.tsx
@@ -14,6 +14,8 @@ import { FlourishEmbed } from '@/components/mdx/FlourishEmbed';
 import ScrollyTelling from '@/components/common/ScrollyTelling';
 import Timeline from '@/components/common/Timeline';
 import RawHtmlEmbed from '@/components/common/RawHtmlEmbed';
+import RelatedArticlesComponent from '@repo/ui/components/RelatedArticles';
+import type { Article } from '@repo/ui/lib/getArticles';
 // import yaml from 'js-yaml';
 
 interface ArticleProps {
@@ -192,6 +194,19 @@ export function ArticleRenderer({
       }
 
       return <Timeline content={content} slug={slug} className="my-8" />;
+    },
+
+    RelatedArticles: (props) => {
+      const pool = (mdxSource.scope as any)?.relatedArticlesPool as Article[] | undefined;
+      return (
+        <RelatedArticlesComponent
+          pool={pool ?? []}
+          articleBasePath="/a"
+          locale="en-US"
+          heading="Read more"
+          {...props}
+        />
+      );
     },
   };
 

--- a/apps/datajournalism.studio/lib/articles.ts
+++ b/apps/datajournalism.studio/lib/articles.ts
@@ -10,6 +10,7 @@ import { remarkBoxPlugin } from './remark-box-plugin'; // Your custom plugin
 import { remarkFlourishPlugin } from './remark-flourish-plugin';
 import type { ScrollyContent } from '@/types/scrolly';
 import type { TimelineContent } from '@/types/timeline';
+import { getArticles } from '@/components/common/getArticles';
 
 
 export async function getArticleBySlug(directorySlug: string) {
@@ -59,9 +60,14 @@ export async function getArticleBySlug(directorySlug: string) {
     timelineData[yamlFile] = yaml.load(timelineFile) as TimelineContent;
   }
 
+  // Pre-fetch article pool for RelatedArticles MDX component
+  const relatedArticlesPool = await getArticles(40, undefined, true);
+  const filteredPool = relatedArticlesPool.filter(a => a.slug !== directorySlug);
+
   const mdxSource = await serialize(content, {
     scope: {
       timelineData: timelineData,
+      relatedArticlesPool: filteredPool,
     },
     mdxOptions: {
       remarkPlugins: [remarkGfm, remarkBoxPlugin, remarkFlourishPlugin],

--- a/apps/web/app/clanek/_articles/zzz-demo-article-features/index.md
+++ b/apps/web/app/clanek/_articles/zzz-demo-article-features/index.md
@@ -28,7 +28,8 @@ This is your practical guide to every tool available when writing articles. Each
 9. [Timeline](#9-timeline)
 10. [Scroll-driven story](#10-scroll-driven-story)
 11. [Custom interactive piece](#11-custom-interactive-piece)
-12. [Quick reference](#12-quick-reference)
+12. [Related articles](#12-related-articles)
+13. [Quick reference](#13-quick-reference)
 
 ---
 
@@ -392,7 +393,31 @@ The HTML file can contain `<style>` and `<script>` blocks. Any paths to images o
 
 ---
 
-## 12. Quick reference
+## 12. Related articles
+
+Use `<RelatedArticles />` to embed a block of recommended articles anywhere in the text. Authors control placement, filtering, and layout entirely through props — no code required.
+
+```md
+<RelatedArticles filter="analýza" count={3} />
+```
+
+<RelatedArticles filter="analýza" count={3} />
+
+Three built-in presets cover the most common layouts:
+
+| Preset | Layout | Use for |
+|--------|--------|---------|
+| `cards` (default) | 3 columns, image top | end of article |
+| `sidebar` | 1 column, thumbnail left, compact | mid-article break |
+| `list` | 1 column, thumbnail left, full detail | podcast or long-form list |
+
+You can also pass `slugs={["slug-one", "slug-two"]}` to show a hand-picked list regardless of category or tag.
+
+Full reference with all options and live examples: [Demo: RelatedArticles — all options](/clanek/zzz-demo-related-articles)
+
+---
+
+## 13. Quick reference
 
 | Feature | Syntax | Notes |
 |---------|--------|-------|
@@ -410,3 +435,4 @@ The HTML file can contain `<style>` and `<script>` blocks. Any paths to images o
 | Timeline | `<Timeline yamlFile="timeline.yaml" />` | Developer creates YAML |
 | ScrollyTelling | `<ScrollyTelling yamlFile="scrollytelling.yaml" />` | Developer creates YAML |
 | Custom HTML | `htmlInclude: "file.html"` in frontmatter | Developer creates HTML |
+| Related articles | `<RelatedArticles filter="analýza" count={3} />` | See [full demo](/clanek/zzz-demo-related-articles) for all options |

--- a/apps/web/app/clanek/_articles/zzz-demo-related-articles/index.md
+++ b/apps/web/app/clanek/_articles/zzz-demo-related-articles/index.md
@@ -1,0 +1,273 @@
+---
+title: "Demo: RelatedArticles — all options"
+date: "9999-12-31"
+author: "Editorial Team"
+excerpt: "Full reference for the RelatedArticles component: presets, sorting, image position, author and date visibility, filtering by category or tag, and hard-coded slug lists."
+tags: ["guide", "reference", "demo"]
+promoted: 0
+---
+
+> This article is hidden from listings (future date). It is a full reference for the **RelatedArticles** component. For a quick introduction see the [article writing guide](/clanek/zzz-demo-article-features).
+
+The `<RelatedArticles />` component lets authors place a block of recommended articles anywhere inside an article. It draws from a pre-fetched pool, filters and sorts on the client side, and renders nothing at all if no articles match.
+
+---
+
+## 1. Presets
+
+A preset sets all layout and visibility defaults at once. Individual props always override the preset.
+
+### `cards` (default) — 3 columns, image on top
+
+```mdx
+<RelatedArticles filter="analýza" count={3} />
+```
+
+<RelatedArticles filter="analýza" count={3} />
+
+---
+
+### `sidebar` — 1 column, thumbnail left, no excerpt
+
+```mdx
+<RelatedArticles filter="kontext" preset="sidebar" count={4} />
+```
+
+<RelatedArticles filter="kontext" preset="sidebar" count={4} />
+
+---
+
+### `list` — 1 column, thumbnail left, everything visible
+
+```mdx
+<RelatedArticles filter="analýza" preset="list" count={3} />
+```
+
+<RelatedArticles filter="analýza" preset="list" count={3} />
+
+---
+
+## 2. Sorting (`sort`)
+
+### `sort="default"` — by score (promotion + recency decay)
+
+```mdx
+<RelatedArticles filter="analýza" count={4} sort="default" heading="Sort: default (score)" />
+```
+
+<RelatedArticles filter="analýza" count={4} sort="default" heading="Sort: default (score)" />
+
+---
+
+### `sort="newest"` — newest article first
+
+```mdx
+<RelatedArticles filter="analýza" count={4} sort="newest" heading="Sort: newest first" />
+```
+
+<RelatedArticles filter="analýza" count={4} sort="newest" heading="Sort: newest first" />
+
+---
+
+## 3. Image position (`imagePosition`)
+
+### `imagePosition="top"`
+
+```mdx
+<RelatedArticles filter="analýza" preset="sidebar" imagePosition="top" count={3} heading="Image: top" />
+```
+
+<RelatedArticles filter="analýza" preset="sidebar" imagePosition="top" count={3} heading="Image: top" />
+
+---
+
+### `imagePosition="left"`
+
+```mdx
+<RelatedArticles filter="analýza" imagePosition="left" count={3} heading="Image: left" />
+```
+
+<RelatedArticles filter="analýza" imagePosition="left" count={3} heading="Image: left" />
+
+---
+
+### `imagePosition="right"`
+
+```mdx
+<RelatedArticles filter="analýza" imagePosition="right" count={3} heading="Image: right" />
+```
+
+<RelatedArticles filter="analýza" imagePosition="right" count={3} heading="Image: right" />
+
+---
+
+### `imagePosition="none"` — no image
+
+```mdx
+<RelatedArticles filter="analýza" imagePosition="none" count={3} heading="Image: hidden" />
+```
+
+<RelatedArticles filter="analýza" imagePosition="none" count={3} heading="Image: hidden" />
+
+---
+
+## 4. Author visibility (`showAuthor`)
+
+### `showAuthor={true}`
+
+```mdx
+<RelatedArticles filter="analýza" showAuthor={true} count={3} heading="Author: visible" />
+```
+
+<RelatedArticles filter="analýza" showAuthor={true} count={3} heading="Author: visible" />
+
+---
+
+### `showAuthor={false}`
+
+```mdx
+<RelatedArticles filter="analýza" showAuthor={false} count={3} heading="Author: hidden" />
+```
+
+<RelatedArticles filter="analýza" showAuthor={false} count={3} heading="Author: hidden" />
+
+---
+
+## 5. Publication date (`showDate`)
+
+### `showDate={true}`
+
+```mdx
+<RelatedArticles filter="analýza" showDate={true} count={3} heading="Date: visible" />
+```
+
+<RelatedArticles filter="analýza" showDate={true} count={3} heading="Date: visible" />
+
+---
+
+### `showDate={false}`
+
+```mdx
+<RelatedArticles filter="analýza" showDate={false} count={3} heading="Date: hidden" />
+```
+
+<RelatedArticles filter="analýza" showDate={false} count={3} heading="Date: hidden" />
+
+---
+
+## 6. Hard-coded slug list (`slugs`)
+
+Bypasses all filtering — displays exactly the articles listed, in the given order.
+
+```mdx
+<RelatedArticles
+  slugs={[
+    "analyza-2025-03-08-zeny-v-politice-cim-vyse-tim-mene-zen",
+    "analyza-2025-03-04-trumpova-obchodni-valka",
+    "analyza-2024-10-17-za-sevcika-se-rekordne-propadl-zajem-uchazecu-o-studium",
+  ]}
+  heading="Selected analyses (fixed list)"
+/>
+```
+
+<RelatedArticles
+  slugs={[
+    "analyza-2025-03-08-zeny-v-politice-cim-vyse-tim-mene-zen",
+    "analyza-2025-03-04-trumpova-obchodni-valka",
+    "analyza-2024-10-17-za-sevcika-se-rekordne-propadl-zajem-uchazecu-o-studium",
+  ]}
+  heading="Selected analyses (fixed list)"
+/>
+
+> When `slugs` is provided, the `filter`, `tag`, and `sort` props are ignored.
+
+---
+
+## 7. No heading
+
+Pass `heading={false}` to suppress the heading and its divider line entirely — useful when embedding the block in a context that already has its own title.
+
+```mdx
+<RelatedArticles filter="analýza" count={3} heading={false} />
+```
+
+<RelatedArticles filter="analýza" count={3} heading={false} />
+
+---
+
+## 8. Filtering
+
+### Array of filters — match any category
+
+```mdx
+<RelatedArticles filter={["analýza", "explainer"]} count={4} heading="Analyses and explainers" />
+```
+
+<RelatedArticles filter={["analýza", "explainer"]} count={4} heading="Analyses and explainers" />
+
+---
+
+### Filter by tag
+
+```mdx
+<RelatedArticles tag="Europarlament" count={4} heading="European Parliament" />
+```
+
+<RelatedArticles tag="Europarlament" count={4} heading="European Parliament" />
+
+---
+
+## 9. No match — nothing renders
+
+When no article in the pool matches the filter, the component renders nothing — not even the heading.
+
+```mdx
+<RelatedArticles filter="nonexistent-category" count={3} />
+```
+
+<RelatedArticles filter="nonexistent-category" count={3} />
+
+_(Nothing above — correct behaviour.)_
+
+---
+
+## All parameters
+
+| Parameter | Type | Default | Values | Description |
+|-----------|------|---------|--------|-------------|
+| `slugs` | `string[]` | — | array of slug strings | Hard-coded article list in given order; overrides `filter`, `tag`, and `sort` |
+| `filter` | `string \| string[]` | — | any `filter` frontmatter value | Filter pool by article category |
+| `tag` | `string` | — | any tag | Filter pool by tag |
+| `count` | `number` | `4` | positive integer | Maximum number of articles to show |
+| `heading` | `string \| false` | `"Čtěte dál"` | any text, or `false` | Section heading; `false` hides the heading and divider |
+| `sort` | `string` | `"default"` | `"default"` `"newest"` | Sort order: score (promotion + recency) or newest first |
+| `preset` | `string` | `"cards"` | `"cards"` `"sidebar"` `"list"` | Layout preset — sets all defaults at once |
+| `columns` | `number` | by preset | `1` `2` `3` `4` | Number of columns |
+| `imagePosition` | `string` | by preset | `"top"` `"left"` `"right"` `"none"` | Thumbnail position |
+| `cardBackground` | `string` | by preset | `"white"` `"cream"` `"transparent"` | Card background colour |
+| `titleSize` | `string` | by preset | `"xs"` `"sm"` `"md"` `"lg"` `"xl"` | Card title size |
+| `showImage` | `boolean` | by preset | `true` `false` | Show thumbnail image |
+| `showAuthor` | `boolean` | by preset | `true` `false` | Show author name |
+| `showDate` | `boolean` | by preset | `true` `false` | Show publication date |
+| `showExcerpt` | `boolean` | by preset | `true` `false` | Show article excerpt |
+| `showReadingTime` | `boolean` | by preset | `true` `false` | Show estimated reading time |
+| `showFormatBadge` | `boolean` | by preset | `true` `false` | Show category badge |
+| `showTopicBadge` | `boolean` | by preset | `true` `false` | Show topic/series badge |
+| `showEmbed` | `boolean` | by preset | `true` `false` | Show embedded player (podcasts) |
+
+### Preset defaults
+
+| Parameter | `cards` | `sidebar` | `list` |
+|-----------|---------|-----------|--------|
+| `columns` | `3` | `1` | `1` |
+| `imagePosition` | `"top"` | `"left"` | `"left"` |
+| `cardBackground` | `"white"` | `"transparent"` | `"white"` |
+| `titleSize` | `"md"` | `"sm"` | `"lg"` |
+| `showImage` | `true` | `true` | `true` |
+| `showAuthor` | `true` | `false` | `true` |
+| `showDate` | `true` | `true` | `true` |
+| `showExcerpt` | `true` | `false` | `true` |
+| `showReadingTime` | `false` | `false` | `true` |
+| `showFormatBadge` | `true` | `true` | `true` |
+| `showTopicBadge` | `false` | `false` | `true` |
+| `showEmbed` | `false` | `false` | `false` |

--- a/apps/web/components/clanek/ArticleRenderer.tsx
+++ b/apps/web/components/clanek/ArticleRenderer.tsx
@@ -20,6 +20,8 @@ import { PartyFace } from '@/components/politics/PartyFace';
 import { MotionsStancesTable } from '@/components/politics/MotionsStancesTable';
 import { normalizeAuthor, splitAuthors } from '@/utils/authorUtils';
 import RawHtmlEmbed from '@/components/common/RawHtmlEmbed';
+import RelatedArticlesComponent from '@repo/ui/components/RelatedArticles';
+import type { Article } from '@repo/ui/lib/getArticles';
 // import yaml from 'js-yaml';
 
 interface ArticleProps {
@@ -205,6 +207,18 @@ export function ArticleRenderer({
       }
 
       return <Timeline content={content} slug={slug} className="my-8" />;
+    },
+
+    RelatedArticles: (props) => {
+      const pool = (mdxSource.scope as any)?.relatedArticlesPool as Article[] | undefined;
+      return (
+        <RelatedArticlesComponent
+          pool={pool ?? []}
+          articleBasePath="/clanek"
+          locale="cs-CZ"
+          {...props}
+        />
+      );
     },
 
   };

--- a/apps/web/lib/articles.ts
+++ b/apps/web/lib/articles.ts
@@ -10,6 +10,7 @@ import { remarkBoxPlugin } from './remark-box-plugin';
 import { remarkFlourishPlugin } from './remark-flourish-plugin';
 import type { ScrollyContent } from '@/types/scrolly';
 import type { TimelineContent } from '@/types/timeline';
+import { getArticles } from '@/components/common/getArticles';
 
 
 const articlesDirectory = path.join(process.cwd(), 'app/clanek/_articles');
@@ -77,10 +78,15 @@ export async function getArticleBySlug(directorySlug: string) {
     }
   }
 
+  // Pre-fetch article pool for RelatedArticles MDX component
+  const relatedArticlesPool = await getArticles(40, undefined, true);
+  const filteredPool = relatedArticlesPool.filter(a => a.slug !== directorySlug);
+
   const mdxSource = await serialize(content, {
     scope: {
       tableData: tableData,
       timelineData: timelineData,
+      relatedArticlesPool: filteredPool,
     },
     mdxOptions: {
       remarkPlugins: [remarkGfm, remarkBoxPlugin, remarkFlourishPlugin],

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
     "./components/ArticlesSection": "./src/components/ArticlesSection.tsx",
     "./components/MediaBox": "./src/components/MediaBox.tsx",
     "./components/InfoBox": "./src/components/InfoBox.tsx",
+    "./components/RelatedArticles": "./src/components/RelatedArticles.tsx",
     "./lib/remark-box-plugin": "./src/lib/remark-box-plugin.js",
     "./lib/remark-flourish-plugin": "./src/lib/remark-flourish-plugin.js",
     "./lib/getArticles": "./src/lib/getArticles.ts",

--- a/packages/ui/src/components/RelatedArticles.tsx
+++ b/packages/ui/src/components/RelatedArticles.tsx
@@ -1,0 +1,414 @@
+'use client';
+
+import {
+  Anchor,
+  Badge,
+  Box,
+  Group,
+  Image,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+  useMantineTheme,
+} from '@mantine/core';
+import type { MantineSize } from '@mantine/core';
+import type { Article } from '../lib/getArticles';
+
+type Preset = 'sidebar' | 'cards' | 'list';
+type ImagePos = 'top' | 'left' | 'right' | 'none';
+type CardBg = 'white' | 'cream' | 'transparent';
+type SortOrder = 'default' | 'newest';
+
+interface RelatedArticlesProps {
+  // Data (injected from scope by ArticleRenderer)
+  pool?: Article[];
+
+  // Filtering (set by author in MDX)
+  filter?: string | string[];
+  tag?: string;
+  slugs?: string[];   // hard-coded list; overrides filter/tag when provided
+  count?: number;
+
+  // Heading — pass false to suppress the heading and its border entirely
+  heading?: string | false;
+
+  // Sort order
+  sort?: SortOrder;
+
+  // Preset
+  preset?: Preset;
+
+  // Layout overrides
+  columns?: 1 | 2 | 3 | 4;
+  imagePosition?: ImagePos;
+  cardBackground?: CardBg;
+  titleSize?: MantineSize;
+
+  // Show/hide toggles
+  showExcerpt?: boolean;
+  showImage?: boolean;
+  showDate?: boolean;
+  showReadingTime?: boolean;
+  showAuthor?: boolean;
+  showFormatBadge?: boolean;
+  showEmbed?: boolean;
+  showTopicBadge?: boolean;
+
+  // App-specific
+  articleBasePath?: string;
+  locale?: string;
+}
+
+interface PresetConfig {
+  columns: 1 | 2 | 3 | 4;
+  imagePosition: ImagePos;
+  cardBackground: CardBg;
+  titleSize: MantineSize;
+  showAuthor: boolean;
+  showExcerpt: boolean;
+  showDate: boolean;
+  showReadingTime: boolean;
+  showFormatBadge: boolean;
+  showTopicBadge: boolean;
+  showEmbed: boolean;
+  showImage: boolean;
+}
+
+const PRESET_DEFAULTS: Record<Preset, PresetConfig> = {
+  sidebar: {
+    columns: 1,
+    imagePosition: 'left',
+    cardBackground: 'transparent',
+    titleSize: 'sm',
+    showAuthor: false,
+    showExcerpt: false,
+    showDate: true,
+    showReadingTime: false,
+    showFormatBadge: true,
+    showTopicBadge: false,
+    showEmbed: false,
+    showImage: true,
+  },
+  cards: {
+    columns: 3,
+    imagePosition: 'top',
+    cardBackground: 'white',
+    titleSize: 'md',
+    showAuthor: true,
+    showExcerpt: true,
+    showDate: true,
+    showReadingTime: false,
+    showFormatBadge: true,
+    showTopicBadge: false,
+    showEmbed: false,
+    showImage: true,
+  },
+  list: {
+    columns: 1,
+    imagePosition: 'left',
+    cardBackground: 'white',
+    titleSize: 'lg',
+    showAuthor: true,
+    showExcerpt: true,
+    showDate: true,
+    showReadingTime: true,
+    showFormatBadge: true,
+    showTopicBadge: true,
+    showEmbed: false,
+    showImage: true,
+  },
+};
+
+function getFilterLabel(filter: string | string[] | undefined): string | null {
+  if (!filter) return null;
+  const first = Array.isArray(filter) ? filter[0] : filter;
+  if (!first) return null;
+  return first.charAt(0).toUpperCase() + first.slice(1);
+}
+
+function useFilterColor(filter: string | string[] | undefined): string {
+  const theme = useMantineTheme();
+  const first = Array.isArray(filter) ? filter[0] : filter;
+  const val = (first ?? '').toLowerCase();
+
+  const map: Record<string, string> = {
+    analýza: theme.colors.brand[6],
+    analyza: theme.colors.brand[6],
+    kontext: theme.colors.brandNavy[6],
+    komentář: theme.colors.brandOrange[6],
+    komentar: theme.colors.brandOrange[6],
+    komentare: theme.colors.brandOrange[6],
+    podcast: theme.colors.brandTeal[6],
+    data: theme.colors.brandTeal[6],
+  };
+
+  return map[val] ?? theme.colors.brand[6];
+}
+
+function cardBgValue(bg: CardBg): string {
+  if (bg === 'white') return 'background.0';
+  if (bg === 'cream') return 'background.1';
+  return 'transparent';
+}
+
+interface MiniCardProps {
+  article: Article;
+  imagePosition: ImagePos;
+  cardBackground: CardBg;
+  titleSize: MantineSize;
+  showExcerpt: boolean;
+  showImage: boolean;
+  showDate: boolean;
+  showReadingTime: boolean;
+  showAuthor: boolean;
+  showFormatBadge: boolean;
+  showEmbed: boolean;
+  showTopicBadge: boolean;
+  articleBasePath: string;
+  locale: string;
+}
+
+function MiniCard({
+  article,
+  imagePosition,
+  cardBackground,
+  titleSize,
+  showExcerpt,
+  showImage,
+  showDate,
+  showReadingTime,
+  showAuthor,
+  showFormatBadge,
+  showEmbed,
+  showTopicBadge,
+  articleBasePath,
+  locale,
+}: MiniCardProps) {
+  const theme = useMantineTheme();
+  const href = `${articleBasePath}/${article.slug}`;
+  const bg = cardBgValue(cardBackground);
+  const filterColor = useFilterColor(article.filter);
+  const filterLabel = getFilterLabel(article.filter);
+
+  const badges = (
+    <Group gap={4} wrap="wrap">
+      {showFormatBadge && filterLabel && (
+        <Badge size="xs" style={{ backgroundColor: filterColor, color: '#fff' }}>
+          {filterLabel}
+        </Badge>
+      )}
+      {showTopicBadge && article.topic && (
+        <Badge size="xs" variant="outline" color="brandNavy.6">
+          {article.topic}
+        </Badge>
+      )}
+    </Group>
+  );
+
+  const dateText = (showDate || showReadingTime) && (
+    <Text size="xs" c="dimmed">
+      {showDate && new Date(article.date).toLocaleDateString(locale)}
+      {showDate && showReadingTime && article.readingTime ? ' · ' : ''}
+      {showReadingTime && article.readingTime ? `${article.readingTime} min` : ''}
+    </Text>
+  );
+
+  const titleEl = (
+    <Anchor href={href} underline="hover" c="inherit">
+      <Text fw={600} size={titleSize} lh={1.3}>
+        {article.title}
+      </Text>
+    </Anchor>
+  );
+
+  const excerpt = showExcerpt && article.excerpt && (
+    <Text size="sm" c="dimmed" lineClamp={3}>
+      {article.excerpt}
+    </Text>
+  );
+
+  const authorText = showAuthor && article.author && (
+    <Text size="xs" c="dimmed">
+      {article.author}
+    </Text>
+  );
+
+  const embed = showEmbed && article.embedHtml && (
+    <Box dangerouslySetInnerHTML={{ __html: article.embedHtml }} />
+  );
+
+  const textBlock = (
+    <Stack gap={4} style={{ flex: 1 }}>
+      {badges}
+      {titleEl}
+      {excerpt}
+      {dateText}
+      {authorText}
+      {embed}
+    </Stack>
+  );
+
+  const hasImage = showImage && article.coverImage;
+
+  if (!hasImage || imagePosition === 'none') {
+    return (
+      <Box bg={bg} p={cardBackground !== 'transparent' ? 'sm' : 0} style={{ borderRadius: 6 }}>
+        {textBlock}
+      </Box>
+    );
+  }
+
+  if (imagePosition === 'top') {
+    return (
+      <Box bg={bg} style={{ borderRadius: 6, overflow: 'hidden' }}>
+        <Anchor href={href} display="block">
+          <Image
+            src={article.coverImage!}
+            alt={article.title}
+            height={140}
+            style={{ objectFit: 'cover', display: 'block', width: '100%' }}
+          />
+        </Anchor>
+        <Box p="sm">
+          {textBlock}
+        </Box>
+      </Box>
+    );
+  }
+
+  // left or right — fixed-size container enforces uniform thumbnail dimensions
+  const imgEl = (
+    <Anchor
+      href={href}
+      style={{ flexShrink: 0, width: 120, height: 90, display: 'block', overflow: 'hidden', borderRadius: 4 }}
+    >
+      <Image
+        src={article.coverImage!}
+        alt={article.title}
+        style={{ objectFit: 'cover', width: '100%', height: '100%', display: 'block' }}
+      />
+    </Anchor>
+  );
+
+  return (
+    <Box bg={bg} p={cardBackground !== 'transparent' ? 'sm' : 0} style={{ borderRadius: 6 }}>
+      <Group gap="sm" align="flex-start" wrap="nowrap">
+        {imagePosition === 'left' && imgEl}
+        {textBlock}
+        {imagePosition === 'right' && imgEl}
+      </Group>
+    </Box>
+  );
+}
+
+export function RelatedArticles({
+  pool = [],
+  filter,
+  tag,
+  slugs,
+  count = 4,
+  heading,
+  sort = 'default',
+  preset = 'cards',
+  columns,
+  imagePosition,
+  cardBackground,
+  titleSize,
+  showExcerpt,
+  showImage,
+  showDate,
+  showReadingTime,
+  showAuthor,
+  showFormatBadge,
+  showEmbed,
+  showTopicBadge,
+  articleBasePath = '/clanek',
+  locale = 'cs-CZ',
+}: RelatedArticlesProps) {
+  const theme = useMantineTheme();
+  const defaults = PRESET_DEFAULTS[preset];
+
+  // Explicit props override preset defaults
+  const effectiveColumns    = columns        ?? defaults.columns;
+  const effectiveImgPos     = imagePosition  ?? defaults.imagePosition;
+  const effectiveBg         = cardBackground ?? defaults.cardBackground;
+  const effectiveTitleSize  = titleSize      ?? defaults.titleSize;
+  const effectiveShowExcerpt      = showExcerpt      ?? defaults.showExcerpt;
+  const effectiveShowImage        = showImage        ?? defaults.showImage;
+  const effectiveShowDate         = showDate         ?? defaults.showDate;
+  const effectiveShowReadingTime  = showReadingTime  ?? defaults.showReadingTime;
+  const effectiveShowAuthor       = showAuthor       ?? defaults.showAuthor;
+  const effectiveShowFormatBadge  = showFormatBadge  ?? defaults.showFormatBadge;
+  const effectiveShowEmbed        = showEmbed        ?? defaults.showEmbed;
+  const effectiveShowTopicBadge   = showTopicBadge   ?? defaults.showTopicBadge;
+
+  const defaultHeading = locale.startsWith('cs') ? 'Čtěte dál' : 'Read more';
+  const effectiveHeading = heading === false ? null : (heading ?? defaultHeading);
+
+  // Build display list
+  let items: Article[];
+  if (slugs && slugs.length > 0) {
+    // Hard-coded list: preserve author-specified order, look up from pool
+    const bySlug = new Map(pool.map(a => [a.slug, a]));
+    items = slugs.flatMap(s => { const a = bySlug.get(s); return a ? [a] : []; });
+  } else {
+    // Filter pool (already sorted by score)
+    items = pool;
+    if (filter) {
+      const f = Array.isArray(filter) ? filter : [filter];
+      items = items.filter(a => {
+        const af = Array.isArray(a.filter) ? a.filter : [a.filter ?? ''];
+        return f.some(v => af.includes(v));
+      });
+    }
+    if (tag) {
+      items = items.filter(a => a.tags?.includes(tag));
+    }
+    if (sort === 'newest') {
+      items = [...items].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    }
+  }
+  const displayed = items.slice(0, count);
+
+  if (displayed.length === 0) return null;
+
+  return (
+    <Box my="xl">
+      {effectiveHeading && (
+        <Title
+          order={3}
+          c="brand.6"
+          mb="xs"
+          pb="xs"
+          style={{ borderBottom: `2px solid ${theme.colors.background[2]}` }}
+        >
+          {effectiveHeading}
+        </Title>
+      )}
+      <SimpleGrid cols={{ base: 1, sm: effectiveColumns }}>
+        {displayed.map(article => (
+          <MiniCard
+            key={article.slug}
+            article={article}
+            imagePosition={effectiveImgPos}
+            cardBackground={effectiveBg}
+            titleSize={effectiveTitleSize}
+            showExcerpt={effectiveShowExcerpt}
+            showImage={effectiveShowImage}
+            showDate={effectiveShowDate}
+            showReadingTime={effectiveShowReadingTime}
+            showAuthor={effectiveShowAuthor}
+            showFormatBadge={effectiveShowFormatBadge}
+            showEmbed={effectiveShowEmbed}
+            showTopicBadge={effectiveShowTopicBadge}
+            articleBasePath={articleBasePath}
+            locale={locale}
+          />
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}
+
+export default RelatedArticles;

--- a/packages/ui/src/lib/getArticles.ts
+++ b/packages/ui/src/lib/getArticles.ts
@@ -13,6 +13,9 @@ export interface Article {
   filter?: string | string[];
   tags: string[];
   promoted?: number;
+  topic?: string;
+  readingTime?: number;
+  embedHtml?: string;
 }
 
 interface ArticleWithScore extends Article {
@@ -66,6 +69,9 @@ export async function getArticles({
           filter: data.filter || [],
           tags: data.tags || [],
           promoted: data.promoted || 0,
+          topic: data.topic ?? undefined,
+          readingTime: data.readingTime ?? undefined,
+          embedHtml: data.embedHtml ?? undefined,
         } as Article;
       } catch {
         return null;


### PR DESCRIPTION
## Summary

- New shared `RelatedArticles` component with three presets (`cards`, `sidebar`, `list`), filtering by category/tag/slug list, sort order, and full show/hide toggles for all metadata fields
- Article interface extended with `topic`, `readingTime`, `embedHtml` fields
- Pool of 40 articles pre-fetched at build time and injected into MDX scope in both apps
- Component registered in both `ArticleRenderer`s
- New `zzz-demo-related-articles` reference article (English, all options with live examples)
- Section 12 + quick reference row added to main demo article

## Test plan

- [x] Local build passes (`npm run build` in `apps/web`)
- [x] Cloudflare preview builds succeeded for both apps
- [x] Demo article renders all sections correctly on preview URL
- [x] Main demo article shows section 12 with live demo and link

🤖 Generated with [Claude Code](https://claude.com/claude-code)