### PR TITLE
KVIFF mapa filmů: oprava kontinentů, mode-aware UX, sekce o Blízkém východu

### DIFF
--- a/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
+++ b/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
@@ -2,12 +2,13 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Badge, Box, Button, Group, Paper, SimpleGrid, Stack, Text, TextInput, Title } from '@mantine/core';
-import { IconSearch, IconX } from '@tabler/icons-react';
+import { IconPlayerPauseFilled, IconPlayerPlayFilled, IconSearch, IconX } from '@tabler/icons-react';
 import { geoNaturalEarth1, geoPath } from 'd3-geo';
 import { feature } from 'topojson-client';
 import { filmCountAvailableRows } from './films';
 import { countryCoordinates, countryPresence2026, czCountry } from './countries';
 import { countryHistory, type CountryYearRow } from './countries-history';
+import { continentHistory } from './continents-history';
 import { CHART_TRACK_BG, NUM_FONT } from './ChartFrame';
 import worldTopology from '../../../public/dpbp/data/world-countries-110m.json';
 
@@ -131,6 +132,10 @@ const filmTotals = Object.fromEntries(
 );
 filmTotals[YEAR_MAX] = KVIFF_2026_FILMS_TOTAL;
 
+const continentByYear = new Map(continentHistory.map((row) => [row.year, row.continents]));
+
+const continentRegions = ['Evropa', 'Severní Amerika', 'Latinská Amerika', 'Asie', 'Blízký východ', 'Afrika', 'Austrálie'];
+
 const countryHistoryWithCurrentYear: CountryYearRow[] = [
   ...countryHistory.filter((row) => row.year !== YEAR_MAX),
   {
@@ -185,6 +190,7 @@ function buildCountries(): CountrySummary[] {
 }
 
 function CountryYearBars({ country, color, selectedYear }: { country: CountrySummary; color: string; selectedYear: number }) {
+  const [hoverYear, setHoverYear] = useState<number | null>(null);
   const years = Array.from({ length: YEAR_MAX - YEAR_MIN + 1 }, (_, i) => YEAR_MIN + i);
   const values = years.map((year) => (MISSED_YEARS.has(year) ? null : country.years[year] ?? 0));
   const max = Math.max(1, ...values.map((value) => value ?? 0));
@@ -196,9 +202,17 @@ function CountryYearBars({ country, color, selectedYear }: { country: CountrySum
   const plotBottom = 88;
   const step = (plotRight - plotLeft) / years.length;
   const barWidth = Math.max(2.5, step * 0.62);
+  const hoverIndex = hoverYear != null ? hoverYear - YEAR_MIN : null;
+  const hoverValue = hoverIndex != null ? values[hoverIndex] : null;
 
   return (
-    <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label={`Sloupcový graf počtu filmů, u kterých je uvedena země ${country.name}`} style={{ width: '100%', height: 126 }}>
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label={`Sloupcový graf počtu filmů, u kterých je uvedena země ${country.name}`}
+      style={{ width: '100%', height: 126 }}
+      onMouseLeave={() => setHoverYear(null)}
+    >
       <line x1={plotLeft} x2={plotRight} y1={plotBottom} y2={plotBottom} stroke="var(--mantine-color-background-6)" strokeWidth={1} />
       {years.map((year, index) => {
         const value = values[index];
@@ -228,14 +242,38 @@ function CountryYearBars({ country, color, selectedYear }: { country: CountrySum
               fill={year === selectedYear ? 'var(--mantine-color-brand-6)' : color}
               opacity={value ? 0.92 : 0.18}
             />
-            {value === max && value > 0 && (
+            {value === max && value > 0 && hoverYear == null && (
               <text x={x + barWidth / 2} y={Math.max(9, plotBottom - h - 4)} textAnchor="middle" fontSize={10} fontWeight={800} fill="var(--mantine-color-dark-9)">
                 {value}
               </text>
             )}
+            <rect
+              x={plotLeft + index * step}
+              y={plotTop}
+              width={step}
+              height={plotBottom - plotTop}
+              fill="transparent"
+              onMouseEnter={() => setHoverYear(year)}
+              style={{ cursor: 'help' }}
+            />
           </g>
         );
       })}
+      {hoverIndex != null && hoverValue != null && (() => {
+        const x = plotLeft + hoverIndex * step + step / 2;
+        const h = (hoverValue / max) * (plotBottom - plotTop);
+        const labelY = Math.max(9, plotBottom - h - 4);
+        const boxWidth = 40;
+        const boxX = Math.min(plotRight - boxWidth, Math.max(plotLeft, x - boxWidth / 2));
+        return (
+          <g pointerEvents="none">
+            <rect x={boxX} y={labelY - 12} width={boxWidth} height={16} rx={3} fill="var(--mantine-color-brandNavy-9)" />
+            <text x={boxX + boxWidth / 2} y={labelY} textAnchor="middle" fontSize={9} fontWeight={900} fill="#fdfbf7">
+              {hoverYear}: {hoverValue}
+            </text>
+          </g>
+        );
+      })()}
       {[1992, 2000, 2010, 2020, 2026].map((tick) => {
         const index = tick - YEAR_MIN;
         return (
@@ -312,18 +350,29 @@ export default function FilmOriginsDashboard() {
   );
   const currentRow = yearRows.get(year);
   const yearTotal = currentRow?.top.reduce((sum, [, count]) => sum + count, 0) ?? 0;
+  const filmsCumulativeToYear = years
+    .filter((item) => item <= year)
+    .reduce((sum, item) => sum + (yearRows.get(item)?.films ?? filmTotals[item] ?? 0), 0);
+  const filmsForCard = mode === 'annual' ? (currentRow?.films ?? filmTotals[year] ?? 0) : filmsCumulativeToYear;
+  const filmsCardLabel = mode === 'annual' ? `filmů v roce ${year}` : `filmů celkem k roku ${year}`;
   const activeCountries = countries.filter((country) => country.years[year]).length;
   const globalMaxAnnual = Math.max(...countries.flatMap((country) => years.map((item) => country.years[item] ?? 0)));
   const globalMaxCumulative = Math.max(...countries.map((country) => country.total));
   const cumulativeFor = (country: CountrySummary) => years.filter((item) => item <= year).reduce((sum, item) => sum + (country.years[item] ?? 0), 0);
   const valueFor = (country: CountrySummary) => (mode === 'annual' ? country.years[year] ?? 0 : cumulativeFor(country));
   const maxForMode = mode === 'annual' ? globalMaxAnnual : globalMaxCumulative;
-  const continentRows = Object.entries(
-    countries.reduce<Record<string, number>>((acc, country) => {
-      acc[country.region] = (acc[country.region] ?? 0) + (country.years[year] ?? 0);
-      return acc;
-    }, {}),
-  ).sort(([, a], [, b]) => b - a);
+  const modeTotal = mode === 'annual' ? yearTotal : countries.reduce((sum, country) => sum + cumulativeFor(country), 0);
+  function continentValueFor(region: string) {
+    if (mode === 'annual') return continentByYear.get(year)?.[region] ?? 0;
+    return years
+      .filter((item) => item <= year)
+      .reduce((sum, item) => sum + (continentByYear.get(item)?.[region] ?? 0), 0);
+  }
+  const continentRows = continentRegions
+    .map((region) => [region, continentValueFor(region)] as [string, number])
+    .filter(([, value]) => value > 0)
+    .sort(([, a], [, b]) => b - a);
+  const continentTotal = continentRows.reduce((sum, [, value]) => sum + value, 0);
   const maxContinent = Math.max(1, ...continentRows.map(([, value]) => value));
   const grandTotal = countries.reduce((sum, country) => sum + country.total, 0);
   const topCountries = countries.slice(0, 10);
@@ -463,13 +512,13 @@ export default function FilmOriginsDashboard() {
           <Text fw={900} style={{ ...NUM_FONT, fontSize: 34 }}>{fmt(currentRow?.coproductions ?? 0)}</Text>
         </Paper>
         <Paper p="md" radius={4} bg="#f8f6f0">
-          <Text c="dimmed" size="sm">filmů celkem</Text>
-          <Text fw={900} style={{ ...NUM_FONT, fontSize: 34 }}>{fmt(currentRow?.films ?? filmTotals[year] ?? 0)}</Text>
+          <Text c="dimmed" size="sm">{filmsCardLabel}</Text>
+          <Text fw={900} style={{ ...NUM_FONT, fontSize: 34 }}>{fmt(filmsForCard)}</Text>
         </Paper>
       </SimpleGrid>
 
-      <SimpleGrid cols={{ base: 1, lg: 3 }} spacing="lg">
-        <Paper p="md" radius={4} bg="#f8f6f0" style={{ gridColumn: '1 / -1' }}>
+      <SimpleGrid cols={{ base: 1, lg: 3 }} spacing="sm">
+        <Paper p="sm" radius={4} bg="#f8f6f0" style={{ gridColumn: '1 / -1' }}>
           <Group justify="end" align="center" mb={6}>
             <Group gap="xs">
               <Button size="compact-sm" color="gray" variant={mode === 'annual' ? 'light' : 'subtle'} onClick={() => setMode('annual')}>Ročně</Button>
@@ -735,25 +784,27 @@ export default function FilmOriginsDashboard() {
                   />
                 );
               })}
-              {mapTooltip && (
-                <g pointerEvents="none">
-                  <rect
-                    x={Math.min(790, Math.max(12, mapTooltip.x + 12))}
-                    y={Math.min(386, Math.max(12, mapTooltip.y - 38))}
-                    width={158}
-                    height={34}
-                    rx={4}
-                    fill="rgba(253, 251, 247, 0.96)"
-                    stroke="var(--mantine-color-background-6)"
-                  />
-                  <text x={Math.min(798, Math.max(20, mapTooltip.x + 20))} y={Math.min(405, Math.max(31, mapTooltip.y - 17))} fontSize={11} fontWeight={900} fill="var(--mantine-color-dark-8)">
-                    {mapTooltip.country.name}
-                  </text>
-                  <text x={Math.min(798, Math.max(20, mapTooltip.x + 20))} y={Math.min(405, Math.max(47, mapTooltip.y - 3))} fontSize={10} fill="var(--mantine-color-dark-5)">
-                    {fmt(mapTooltip.value)} {filmPlural(mapTooltip.value)}
-                  </text>
-                </g>
-              )}
+              {mapTooltip && (() => {
+                const share = modeTotal ? Math.round((mapTooltip.value / modeTotal) * 1000) / 10 : null;
+                const boxX = Math.min(790, Math.max(12, mapTooltip.x + 12));
+                const boxY = Math.min(372, Math.max(12, mapTooltip.y - 52));
+                return (
+                  <g pointerEvents="none">
+                    <rect x={boxX} y={boxY} width={158} height={48} rx={4} fill="rgba(253, 251, 247, 0.96)" stroke="var(--mantine-color-background-6)" />
+                    <text x={boxX + 10} y={boxY + 16} fontSize={11} fontWeight={900} fill="var(--mantine-color-dark-8)">
+                      {mapTooltip.country.name}
+                    </text>
+                    <text x={boxX + 10} y={boxY + 32} fontSize={10} fill="var(--mantine-color-dark-5)">
+                      {fmt(mapTooltip.value)} {filmPlural(mapTooltip.value)}
+                    </text>
+                    {share != null && (
+                      <text x={boxX + 10} y={boxY + 44} fontSize={10} fill="var(--mantine-color-dark-5)">
+                        {pct(share)} % z {mode === 'annual' ? 'ročníku' : 'celkové řady'}
+                      </text>
+                    )}
+                  </g>
+                );
+              })()}
               {mapLabels.map(({ country, x, y, anchor, fontSize }) => {
                 return (
                   <text
@@ -846,25 +897,30 @@ export default function FilmOriginsDashboard() {
 
           <Stack gap={8} mt="md">
             <Group gap={8} align="end" wrap="nowrap">
-              <Box style={{ width: 126, minWidth: 126 }}>
+              <Box style={{ width: 126, minWidth: 126, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
                 <Text size="xs" c="dimmed" ta="center" mb={4} style={{ whiteSpace: 'nowrap' }}>kliknutím vybrat rok</Text>
                 <button
                   type="button"
                   onClick={() => setIsPlaying((current) => !current)}
                   aria-label={isPlaying ? 'Pozastavit přehrávání roků' : 'Přehrát roky'}
                   style={{
-                    width: '100%',
-                    height: 26,
-                    border: '1px solid var(--mantine-color-background-6)',
-                    borderRadius: 4,
-                    background: isPlaying ? 'var(--mantine-color-brand-6)' : 'var(--mantine-color-background-0)',
-                    color: isPlaying ? 'white' : 'var(--mantine-color-dark-8)',
+                    width: 30,
+                    height: 30,
+                    border: 0,
+                    borderRadius: 999,
+                    background: 'var(--mantine-color-brand-6)',
+                    color: 'white',
                     cursor: 'pointer',
-                    fontSize: 13,
-                    fontWeight: 900,
+                    display: 'grid',
+                    placeItems: 'center',
+                    boxShadow: '0 2px 6px rgba(16, 20, 50, 0.25)',
                   }}
                 >
-                  {isPlaying ? 'II' : '▶'}
+                  {isPlaying ? (
+                    <IconPlayerPauseFilled size={14} />
+                  ) : (
+                    <IconPlayerPlayFilled size={14} style={{ marginLeft: 1 }} />
+                  )}
                 </button>
               </Box>
               <Box
@@ -925,12 +981,40 @@ export default function FilmOriginsDashboard() {
         </Paper>
 
         <Paper p="lg" radius={4} bg="#f8f6f0">
-          <Title order={3} size="1.05rem" mb="md">Kontinenty v roce {year}</Title>
+          <Title order={3} size="1.05rem" mb="md">
+            {mode === 'annual' ? `Kontinenty v roce ${year}` : `Kontinenty celkem do roku ${year}`}
+          </Title>
           <Stack gap={7}>
             {continentRows.map(([region, value]) => (
               <DashboardBar key={region} label={normalizeRegion(region)} value={value} max={maxContinent} color={regionColors[normalizeRegion(region)] ?? regionColors.Ostatní} />
             ))}
           </Stack>
+          <Box mt="md">
+            <Text size="xs" c="dimmed" mb={4}>Stejná data jako podíl na katalogu (100 %)</Text>
+            <Box style={{ display: 'flex', height: 22, borderRadius: 4, overflow: 'hidden' }}>
+              {continentRows.map(([region, value]) => {
+                const width = continentTotal ? (value / continentTotal) * 100 : 0;
+                if (width < 0.5) return null;
+                return (
+                  <Box
+                    key={region}
+                    title={`${normalizeRegion(region)}: ${fmt(value)} (${pct((value / continentTotal) * 100)} %)`}
+                    style={{
+                      width: `${width}%`,
+                      background: regionColors[normalizeRegion(region)] ?? regionColors.Ostatní,
+                      display: 'grid',
+                      placeItems: 'center',
+                      minWidth: width > 4 ? undefined : 0,
+                    }}
+                  >
+                    {width > 6 && (
+                      <Text fw={900} c="white" style={{ ...NUM_FONT, fontSize: 10 }}>{fmt(value)}</Text>
+                    )}
+                  </Box>
+                );
+              })}
+            </Box>
+          </Box>
         </Paper>
       </SimpleGrid>
 

--- a/apps/web/app/specialy/kviff/FilmScreeningsChart.tsx
+++ b/apps/web/app/specialy/kviff/FilmScreeningsChart.tsx
@@ -26,6 +26,10 @@ export default function FilmScreeningsChart({
   const showDensity = active.has('density');
 
   const maxScreenings = Math.max(...rows.map((row) => row.screenings ?? 0));
+  const sharedMax = Math.max(maxFilms, maxScreenings);
+  const axisStep = sharedMax > 400 ? 100 : sharedMax > 200 ? 50 : 25;
+  const axisMax = Math.ceil(sharedMax / axisStep) * axisStep;
+  const axisTicks = Array.from({ length: axisMax / axisStep }, (_, i) => (i + 1) * axisStep);
   const screeningDensityRows = rows
     .map((row, index) => ({
       row,
@@ -66,6 +70,32 @@ export default function FilmScreeningsChart({
             paddingTop: 8,
           }}
         >
+          <Box
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              inset: '2px 0 28px 0',
+              pointerEvents: 'none',
+              zIndex: 0,
+            }}
+          >
+            <svg viewBox="0 0 1000 198" preserveAspectRatio="none" width="100%" height="100%">
+              <text x="10" y="16" fill="var(--mantine-color-dark-5)" fontSize="20" fontWeight="900">
+                filmy / projekce
+              </text>
+              {axisTicks.map((tick) => {
+                const y = 18 + (1 - tick / axisMax) * 170;
+                return (
+                  <g key={tick}>
+                    <line x1="0" x2="1000" y1={y} y2={y} stroke="var(--mantine-color-background-6)" strokeDasharray="6 10" strokeWidth="1.5" />
+                    <text x="10" y={Math.max(28, y - 5)} fill="var(--mantine-color-dark-5)" fontSize="20" fontWeight="900">
+                      {tick}
+                    </text>
+                  </g>
+                );
+              })}
+            </svg>
+          </Box>
           <Box
             aria-hidden="true"
             style={{
@@ -120,8 +150,8 @@ export default function FilmScreeningsChart({
             </svg>
           </Box>
           {rows.map((row) => {
-            const filmsHeight = Math.max(10, Math.round(((row.totalFilms ?? 0) / maxFilms) * 190));
-            const screeningsHeight = row.screenings ? Math.max(10, Math.round((row.screenings / maxScreenings) * 190)) : 0;
+            const filmsHeight = Math.max(10, Math.round(((row.totalFilms ?? 0) / axisMax) * 190));
+            const screeningsHeight = row.screenings ? Math.max(10, Math.round((row.screenings / axisMax) * 190)) : 0;
             const perFilm = row.screenings && row.totalFilms ? Math.round((row.screenings / row.totalFilms) * 100) / 100 : null;
             const tooltip = [
               `${row.year}${row.edition ? ` · ${row.edition}. ročník` : ''}`,
@@ -172,6 +202,9 @@ export default function FilmScreeningsChart({
           })}
         </Box>
       </Box>
+      <Text size="xs" c="dimmed" mt={4}>
+        Levá osa (filmy, projekce) i pravá osa (projekce/film) začínají na nule a mají nezávislé měřítko – graf srovnává tvar vývoje, ne přímou velikost mezi osami.
+      </Text>
     </div>
   );
 }

--- a/apps/web/app/specialy/kviff/[slug]/page.tsx
+++ b/apps/web/app/specialy/kviff/[slug]/page.tsx
@@ -20,6 +20,7 @@ import { honoraryByPeriod, honoraryCrystalGlobeRecipients, honoraryDoubleWomanYe
 import { completeBreakdownRows, filmCountAvailableRows, filmScaleByPeriod, firstScreeningsPerFilm, latestClosedFilmYear, latestScreeningsPerFilm, peakFilmYear } from '../films';
 import { countryPresence2026, countryPresenceMax, countryPresenceTop, countryPresenceTotal, countryRegionTotals } from '../countries';
 import { countryHistory, countryHistoryTopCountries } from '../countries-history';
+import { continentHistory } from '../continents-history';
 import HonoraryTimeline from '../HonoraryTimeline';
 import ProgramBreakdownChart from '../ProgramBreakdownChart';
 import FilmScreeningsChart from '../FilmScreeningsChart';
@@ -125,6 +126,44 @@ const countryHistoryPeriods = [
       })),
   };
 });
+
+const middleEastByPeriod = [
+  { period: '1992–2003', from: 1992, to: 2003 },
+  { period: '2004–2017', from: 2004, to: 2017 },
+  { period: '2018–2026', from: 2018, to: 2026 },
+].map(({ period, from, to }) => {
+  const rows = continentHistory.filter((row) => row.year >= from && row.year <= to);
+  const middleEast = rows.reduce((sum, row) => sum + (row.continents['Blízký východ'] ?? 0), 0);
+  const total = rows.reduce((sum, row) => sum + Object.values(row.continents).reduce((a, b) => a + b, 0), 0);
+  return { period, share: Math.round((middleEast / total) * 1000) / 10 };
+});
+const maxMiddleEastShare = Math.max(...middleEastByPeriod.map((row) => row.share));
+
+function MiddleEastPanel() {
+  return (
+    <ChartFrame
+      title="Blízký východ získává na mapě víc místa"
+      subtitle="Podíl Blízkého východu na všech účastech produkčních zemí v katalogu, podle období"
+      source="kviff_continents_corrected_all_years.csv – opravený souhrn proti dvojímu počítání kontinentů u koprodukcí"
+      fullWidth
+    >
+      <Text size="lg">
+        V prvních dvanácti ročnících po roce 1992 tvořil Blízký východ jen {formatPercent(middleEastByPeriod[0].share)} všech účastí produkčních zemí v katalogu. V období 2004–2017 to bylo už {formatPercent(middleEastByPeriod[1].share)} a v posledních ročnících 2018–2026 {formatPercent(middleEastByPeriod[2].share)} – podíl se tedy za tři období víc než ztrojnásobil, i když celkový katalog byl v posledním období menší než v tom prvním.
+      </Text>
+      <Text mt="sm">
+        Nejde o to, že by Blízký východ najednou dodával desítky filmů ročně – v absolutních číslech pořád jde o menší kinematografie než evropská nebo severoamerická produkce. Roste ale jeho stabilní přítomnost v programu napříč ročníky, na rozdíl třeba od jednorázových vln typu Jižní Koreje 2001 nebo Austrálie 1997. To je čitelnější jako dlouhodobý posun v koprodukční síti a programové dramaturgii než jako náhodný výkyv jednoho ročníku.
+      </Text>
+      <Stack gap="sm" mt="lg">
+        {middleEastByPeriod.map((row) => (
+          <DataBar key={row.period} label={row.period} value={row.share} max={maxMiddleEastShare} color="var(--mantine-color-brandNavy-6)" suffix="%" />
+        ))}
+      </Stack>
+      <Text mt="md" size="sm" c="dimmed">
+        Podíl počítáme z účastí produkčních zemí (koprodukce se do kontinentu započítá jednou, i když má víc zemí ze stejného kontinentu), ne z počtu filmů – jde o vnitřní trend KVIFF, ne o srovnání s jinými festivaly nebo se světovou filmovou produkcí.
+      </Text>
+    </ChartFrame>
+  );
+}
 
 function HonoraryDotTimeline() {
   return (
@@ -742,9 +781,18 @@ function ProgramCompositionGraphic({ maxFilms }: { maxFilms: number }) {
       </Text>
 
       <Box mb="xl">
-        <Group justify="space-between" mb={6}>
+        <Group justify="space-between" mb={6} wrap="wrap">
           <Text fw={900}>Celá dostupná řada: kolik filmů festival uváděl</Text>
-          <Text size="sm" c="dimmed">zvýrazněné roky mají úplné členění</Text>
+          <Group gap={12} wrap="nowrap">
+            <Group gap={5} wrap="nowrap">
+              <Box w={9} h={9} bg="var(--mantine-color-brandTeal-6)" style={{ borderRadius: 999, flex: '0 0 auto' }} />
+              <Text size="sm" c="dimmed">má členění</Text>
+            </Group>
+            <Group gap={5} wrap="nowrap">
+              <Box w={9} h={9} bg="var(--mantine-color-background-7)" style={{ borderRadius: 999, flex: '0 0 auto' }} />
+              <Text size="sm" c="dimmed">jen celkový počet</Text>
+            </Group>
+          </Group>
         </Group>
         <Box style={{ overflowX: 'auto', paddingBottom: 8 }}>
           <Box
@@ -826,6 +874,8 @@ function FilmScaleBlock() {
       >
         <FilmOriginsDashboard />
       </ChartFrame>
+
+      <MiddleEastPanel />
 
       <ChartFrame
         title="Program se po maximu zmenšil, ale zhoustl"

--- a/apps/web/app/specialy/kviff/_pipeline/build_continents_history_ts.py
+++ b/apps/web/app/specialy/kviff/_pipeline/build_continents_history_ts.py
@@ -1,0 +1,34 @@
+# Z kviff_continents_corrected_all_years.csv vygeneruje ../continents-history.ts.
+# Zdroj CSV je ručně opravený tak, aby koprodukce se dvěma zeměmi ze stejného
+# kontinentu (např. USA + Brazílie + Argentina) nezapočítávala kontinent
+# vícekrát – na rozdíl od countries-history.ts, kde se dvojí počítání děje,
+# protože se tam sčítají jednotlivé země, ne unikátní kontinenty na film.
+
+import csv
+import json
+from collections import OrderedDict
+from pathlib import Path
+
+HERE = Path(__file__).parent
+rows = OrderedDict()
+with (HERE / 'kviff_continents_corrected_all_years.csv').open(encoding='utf-8') as f:
+    for row in csv.DictReader(f):
+        year = int(row['year'])
+        rows.setdefault(year, {})[row['continent']] = int(row['value'])
+
+out_rows = [{'year': year, 'continents': continents} for year, continents in sorted(rows.items())]
+
+ts = ['// GENEROVANO: _pipeline/build_continents_history_ts.py',
+      '// (zdroj: kviff_continents_corrected_all_years.csv, rucne opravene proti',
+      '// dvojimu pocitani kontinentu u koprodukci se dvema a vice zememi ze',
+      '// stejneho kontinentu)',
+      '',
+      'export type ContinentYearRow = {',
+      '  year: number;',
+      '  continents: Record<string, number>;',
+      '};',
+      '',
+      'export const continentHistory: ContinentYearRow[] = ' + json.dumps(out_rows, ensure_ascii=False, indent=1) + ';',
+      '']
+(HERE.parent / 'continents-history.ts').write_text('\n'.join(ts), encoding='utf-8')
+print('zapsano continents-history.ts,', len(out_rows), 'rocniku')

--- a/apps/web/app/specialy/kviff/_pipeline/kviff_continents_corrected_all_years.csv
+++ b/apps/web/app/specialy/kviff/_pipeline/kviff_continents_corrected_all_years.csv
@@ -1,0 +1,224 @@
+year,continent,value
+1992,Evropa,13
+1992,Severní Amerika,1
+1992,Asie,1
+1992,Blízký východ,2
+1992,Austrálie,1
+1994,Evropa,126
+1994,Severní Amerika,20
+1994,Latinská Amerika,2
+1994,Asie,9
+1994,Austrálie,1
+1995,Evropa,115
+1995,Severní Amerika,39
+1995,Latinská Amerika,4
+1995,Asie,13
+1995,Blízký východ,3
+1995,Afrika,1
+1995,Austrálie,1
+1996,Evropa,107
+1996,Severní Amerika,46
+1996,Latinská Amerika,2
+1996,Asie,21
+1996,Blízký východ,4
+1996,Austrálie,1
+1997,Evropa,140
+1997,Severní Amerika,70
+1997,Latinská Amerika,1
+1997,Asie,13
+1997,Blízký východ,5
+1997,Afrika,1
+1997,Austrálie,24
+1998,Evropa,126
+1998,Severní Amerika,55
+1998,Latinská Amerika,7
+1998,Asie,28
+1998,Blízký východ,2
+1998,Afrika,2
+1998,Austrálie,3
+1999,Evropa,129
+1999,Severní Amerika,26
+1999,Latinská Amerika,2
+1999,Asie,13
+1999,Blízký východ,4
+2000,Evropa,173
+2000,Severní Amerika,41
+2000,Latinská Amerika,3
+2000,Asie,24
+2000,Blízký východ,4
+2000,Afrika,2
+2000,Austrálie,4
+2001,Evropa,165
+2001,Severní Amerika,40
+2001,Latinská Amerika,16
+2001,Asie,44
+2001,Blízký východ,8
+2001,Austrálie,2
+2002,Evropa,191
+2002,Severní Amerika,43
+2002,Latinská Amerika,29
+2002,Asie,37
+2002,Blízký východ,8
+2002,Afrika,2
+2002,Austrálie,5
+2003,Evropa,195
+2003,Severní Amerika,44
+2003,Latinská Amerika,11
+2003,Asie,29
+2003,Blízký východ,9
+2003,Afrika,3
+2003,Austrálie,5
+2004,Evropa,156
+2004,Severní Amerika,43
+2004,Latinská Amerika,10
+2004,Asie,24
+2004,Blízký východ,21
+2004,Afrika,1
+2004,Austrálie,2
+2005,Evropa,186
+2005,Severní Amerika,62
+2005,Latinská Amerika,15
+2005,Asie,28
+2005,Blízký východ,14
+2005,Afrika,5
+2005,Austrálie,3
+2006,Evropa,167
+2006,Severní Amerika,66
+2006,Latinská Amerika,20
+2006,Asie,20
+2006,Blízký východ,11
+2006,Afrika,5
+2006,Austrálie,4
+2007,Evropa,186
+2007,Severní Amerika,42
+2007,Latinská Amerika,10
+2007,Asie,34
+2007,Blízký východ,6
+2007,Afrika,3
+2007,Austrálie,3
+2008,Evropa,174
+2008,Severní Amerika,46
+2008,Latinská Amerika,14
+2008,Asie,15
+2008,Blízký východ,6
+2008,Afrika,1
+2008,Austrálie,3
+2009,Evropa,166
+2009,Severní Amerika,38
+2009,Latinská Amerika,13
+2009,Asie,25
+2009,Blízký východ,10
+2009,Afrika,2
+2009,Austrálie,4
+2010,Evropa,154
+2010,Severní Amerika,27
+2010,Latinská Amerika,7
+2010,Asie,13
+2010,Blízký východ,10
+2010,Afrika,1
+2010,Austrálie,10
+2011,Evropa,148
+2011,Severní Amerika,46
+2011,Latinská Amerika,7
+2011,Asie,12
+2011,Blízký východ,6
+2011,Afrika,1
+2011,Austrálie,1
+2012,Evropa,173
+2012,Severní Amerika,29
+2012,Latinská Amerika,6
+2012,Asie,10
+2012,Blízký východ,13
+2012,Afrika,2
+2012,Austrálie,3
+2013,Evropa,165
+2013,Severní Amerika,47
+2013,Latinská Amerika,9
+2013,Asie,21
+2013,Blízký východ,21
+2013,Afrika,2
+2013,Austrálie,2
+2014,Evropa,185
+2014,Severní Amerika,34
+2014,Latinská Amerika,9
+2014,Asie,28
+2014,Blízký východ,8
+2014,Afrika,3
+2014,Austrálie,5
+2015,Evropa,170
+2015,Severní Amerika,33
+2015,Latinská Amerika,11
+2015,Asie,16
+2015,Blízký východ,15
+2015,Afrika,1
+2015,Austrálie,4
+2016,Evropa,140
+2016,Severní Amerika,38
+2016,Latinská Amerika,14
+2016,Asie,21
+2016,Blízký východ,15
+2016,Afrika,2
+2016,Austrálie,1
+2017,Evropa,148
+2017,Severní Amerika,31
+2017,Latinská Amerika,9
+2017,Asie,31
+2017,Blízký východ,13
+2017,Afrika,1
+2017,Austrálie,1
+2018,Evropa,164
+2018,Severní Amerika,64
+2018,Latinská Amerika,16
+2018,Asie,13
+2018,Blízký východ,13
+2018,Afrika,2
+2018,Austrálie,3
+2019,Evropa,133
+2019,Severní Amerika,34
+2019,Latinská Amerika,12
+2019,Asie,9
+2019,Blízký východ,17
+2019,Afrika,5
+2019,Austrálie,1
+2021,Evropa,113
+2021,Severní Amerika,25
+2021,Latinská Amerika,8
+2021,Asie,17
+2021,Blízký východ,17
+2021,Afrika,3
+2021,Austrálie,1
+2022,Evropa,128
+2022,Severní Amerika,41
+2022,Latinská Amerika,11
+2022,Asie,13
+2022,Blízký východ,16
+2022,Afrika,7
+2022,Austrálie,5
+2023,Evropa,135
+2023,Severní Amerika,23
+2023,Latinská Amerika,7
+2023,Asie,32
+2023,Blízký východ,23
+2023,Afrika,6
+2023,Austrálie,2
+2024,Evropa,142
+2024,Severní Amerika,44
+2024,Latinská Amerika,8
+2024,Asie,26
+2024,Blízký východ,13
+2024,Afrika,6
+2024,Austrálie,1
+2025,Evropa,129
+2025,Severní Amerika,44
+2025,Latinská Amerika,9
+2025,Asie,14
+2025,Blízký východ,12
+2025,Afrika,2
+2025,Austrálie,3
+2026,Evropa,140
+2026,Severní Amerika,31
+2026,Latinská Amerika,19
+2026,Asie,14
+2026,Blízký východ,8
+2026,Afrika,2
+2026,Austrálie,1

--- a/apps/web/app/specialy/kviff/continents-history.ts
+++ b/apps/web/app/specialy/kviff/continents-history.ts
@@ -1,0 +1,400 @@
+// GENEROVANO: _pipeline/build_continents_history_ts.py
+// (zdroj: kviff_continents_corrected_all_years.csv, rucne opravene proti
+// dvojimu pocitani kontinentu u koprodukci se dvema a vice zememi ze
+// stejneho kontinentu)
+
+export type ContinentYearRow = {
+  year: number;
+  continents: Record<string, number>;
+};
+
+export const continentHistory: ContinentYearRow[] = [
+ {
+  "year": 1992,
+  "continents": {
+   "Evropa": 13,
+   "Severní Amerika": 1,
+   "Asie": 1,
+   "Blízký východ": 2,
+   "Austrálie": 1
+  }
+ },
+ {
+  "year": 1994,
+  "continents": {
+   "Evropa": 126,
+   "Severní Amerika": 20,
+   "Latinská Amerika": 2,
+   "Asie": 9,
+   "Austrálie": 1
+  }
+ },
+ {
+  "year": 1995,
+  "continents": {
+   "Evropa": 115,
+   "Severní Amerika": 39,
+   "Latinská Amerika": 4,
+   "Asie": 13,
+   "Blízký východ": 3,
+   "Afrika": 1,
+   "Austrálie": 1
+  }
+ },
+ {
+  "year": 1996,
+  "continents": {
+   "Evropa": 107,
+   "Severní Amerika": 46,
+   "Latinská Amerika": 2,
+   "Asie": 21,
+   "Blízký východ": 4,
+   "Austrálie": 1
+  }
+ },
+ {
+  "year": 1997,
+  "continents": {
+   "Evropa": 140,
+   "Severní Amerika": 70,
+   "Latinská Amerika": 1,
+   "Asie": 13,
+   "Blízký východ": 5,
+   "Afrika": 1,
+   "Austrálie": 24
+  }
+ },
+ {
+  "year": 1998,
+  "continents": {
+   "Evropa": 126,
+   "Severní Amerika": 55,
+   "Latinská Amerika": 7,
+   "Asie": 28,
+   "Blízký východ": 2,
+   "Afrika": 2,
+   "Austrálie": 3
+  }
+ },
+ {
+  "year": 1999,
+  "continents": {
+   "Evropa": 129,
+   "Severní Amerika": 26,
+   "Latinská Amerika": 2,
+   "Asie": 13,
+   "Blízký východ": 4
+  }
+ },
+ {
+  "year": 2000,
+  "continents": {
+   "Evropa": 173,
+   "Severní Amerika": 41,
+   "Latinská Amerika": 3,
+   "Asie": 24,
+   "Blízký východ": 4,
+   "Afrika": 2,
+   "Austrálie": 4
+  }
+ },
+ {
+  "year": 2001,
+  "continents": {
+   "Evropa": 165,
+   "Severní Amerika": 40,
+   "Latinská Amerika": 16,
+   "Asie": 44,
+   "Blízký východ": 8,
+   "Austrálie": 2
+  }
+ },
+ {
+  "year": 2002,
+  "continents": {
+   "Evropa": 191,
+   "Severní Amerika": 43,
+   "Latinská Amerika": 29,
+   "Asie": 37,
+   "Blízký východ": 8,
+   "Afrika": 2,
+   "Austrálie": 5
+  }
+ },
+ {
+  "year": 2003,
+  "continents": {
+   "Evropa": 195,
+   "Severní Amerika": 44,
+   "Latinská Amerika": 11,
+   "Asie": 29,
+   "Blízký východ": 9,
+   "Afrika": 3,
+   "Austrálie": 5
+  }
+ },
+ {
+  "year": 2004,
+  "continents": {
+   "Evropa": 156,
+   "Severní Amerika": 43,
+   "Latinská Amerika": 10,
+   "Asie": 24,
+   "Blízký východ": 21,
+   "Afrika": 1,
+   "Austrálie": 2
+  }
+ },
+ {
+  "year": 2005,
+  "continents": {
+   "Evropa": 186,
+   "Severní Amerika": 62,
+   "Latinská Amerika": 15,
+   "Asie": 28,
+   "Blízký východ": 14,
+   "Afrika": 5,
+   "Austrálie": 3
+  }
+ },
+ {
+  "year": 2006,
+  "continents": {
+   "Evropa": 167,
+   "Severní Amerika": 66,
+   "Latinská Amerika": 20,
+   "Asie": 20,
+   "Blízký východ": 11,
+   "Afrika": 5,
+   "Austrálie": 4
+  }
+ },
+ {
+  "year": 2007,
+  "continents": {
+   "Evropa": 186,
+   "Severní Amerika": 42,
+   "Latinská Amerika": 10,
+   "Asie": 34,
+   "Blízký východ": 6,
+   "Afrika": 3,
+   "Austrálie": 3
+  }
+ },
+ {
+  "year": 2008,
+  "continents": {
+   "Evropa": 174,
+   "Severní Amerika": 46,
+   "Latinská Amerika": 14,
+   "Asie": 15,
+   "Blízký východ": 6,
+   "Afrika": 1,
+   "Austrálie": 3
+  }
+ },
+ {
+  "year": 2009,
+  "continents": {
+   "Evropa": 166,
+   "Severní Amerika": 38,
+   "Latinská Amerika": 13,
+   "Asie": 25,
+   "Blízký východ": 10,
+   "Afrika": 2,
+   "Austrálie": 4
+  }
+ },
+ {
+  "year": 2010,
+  "continents": {
+   "Evropa": 154,
+   "Severní Amerika": 27,
+   "Latinská Amerika": 7,
+   "Asie": 13,
+   "Blízký východ": 10,
+   "Afrika": 1,
+   "Austrálie": 10
+  }
+ },
+ {
+  "year": 2011,
+  "continents": {
+   "Evropa": 148,
+   "Severní Amerika": 46,
+   "Latinská Amerika": 7,
+   "Asie": 12,
+   "Blízký východ": 6,
+   "Afrika": 1,
+   "Austrálie": 1
+  }
+ },
+ {
+  "year": 2012,
+  "continents": {
+   "Evropa": 173,
+   "Severní Amerika": 29,
+   "Latinská Amerika": 6,
+   "Asie": 10,
+   "Blízký východ": 13,
+   "Afrika": 2,
+   "Austrálie": 3
+  }
+ },
+ {
+  "year": 2013,
+  "continents": {
+   "Evropa": 165,
+   "Severní Amerika": 47,
+   "Latinská Amerika": 9,
+   "Asie": 21,
+   "Blízký východ": 21,
+   "Afrika": 2,
+   "Austrálie": 2
+  }
+ },
+ {
+  "year": 2014,
+  "continents": {
+   "Evropa": 185,
+   "Severní Amerika": 34,
+   "Latinská Amerika": 9,
+   "Asie": 28,
+   "Blízký východ": 8,
+   "Afrika": 3,
+   "Austrálie": 5
+  }
+ },
+ {
+  "year": 2015,
+  "continents": {
+   "Evropa": 170,
+   "Severní Amerika": 33,
+   "Latinská Amerika": 11,
+   "Asie": 16,
+   "Blízký východ": 15,
+   "Afrika": 1,
+   "Austrálie": 4
+  }
+ },
+ {
+  "year": 2016,
+  "continents": {
+   "Evropa": 140,
+   "Severní Amerika": 38,
+   "Latinská Amerika": 14,
+   "Asie": 21,
+   "Blízký východ": 15,
+   "Afrika": 2,
+   "Austrálie": 1
+  }
+ },
+ {
+  "year": 2017,
+  "continents": {
+   "Evropa": 148,
+   "Severní Amerika": 31,
+   "Latinská Amerika": 9,
+   "Asie": 31,
+   "Blízký východ": 13,
+   "Afrika": 1,
+   "Austrálie": 1
+  }
+ },
+ {
+  "year": 2018,
+  "continents": {
+   "Evropa": 164,
+   "Severní Amerika": 64,
+   "Latinská Amerika": 16,
+   "Asie": 13,
+   "Blízký východ": 13,
+   "Afrika": 2,
+   "Austrálie": 3
+  }
+ },
+ {
+  "year": 2019,
+  "continents": {
+   "Evropa": 133,
+   "Severní Amerika": 34,
+   "Latinská Amerika": 12,
+   "Asie": 9,
+   "Blízký východ": 17,
+   "Afrika": 5,
+   "Austrálie": 1
+  }
+ },
+ {
+  "year": 2021,
+  "continents": {
+   "Evropa": 113,
+   "Severní Amerika": 25,
+   "Latinská Amerika": 8,
+   "Asie": 17,
+   "Blízký východ": 17,
+   "Afrika": 3,
+   "Austrálie": 1
+  }
+ },
+ {
+  "year": 2022,
+  "continents": {
+   "Evropa": 128,
+   "Severní Amerika": 41,
+   "Latinská Amerika": 11,
+   "Asie": 13,
+   "Blízký východ": 16,
+   "Afrika": 7,
+   "Austrálie": 5
+  }
+ },
+ {
+  "year": 2023,
+  "continents": {
+   "Evropa": 135,
+   "Severní Amerika": 23,
+   "Latinská Amerika": 7,
+   "Asie": 32,
+   "Blízký východ": 23,
+   "Afrika": 6,
+   "Austrálie": 2
+  }
+ },
+ {
+  "year": 2024,
+  "continents": {
+   "Evropa": 142,
+   "Severní Amerika": 44,
+   "Latinská Amerika": 8,
+   "Asie": 26,
+   "Blízký východ": 13,
+   "Afrika": 6,
+   "Austrálie": 1
+  }
+ },
+ {
+  "year": 2025,
+  "continents": {
+   "Evropa": 129,
+   "Severní Amerika": 44,
+   "Latinská Amerika": 9,
+   "Asie": 14,
+   "Blízký východ": 12,
+   "Afrika": 2,
+   "Austrálie": 3
+  }
+ },
+ {
+  "year": 2026,
+  "continents": {
+   "Evropa": 140,
+   "Severní Amerika": 31,
+   "Latinská Amerika": 19,
+   "Asie": 14,
+   "Blízký východ": 8,
+   "Afrika": 2,
+   "Austrálie": 1
+  }
+ }
+];

--- a/apps/web/app/specialy/kviff/films.ts
+++ b/apps/web/app/specialy/kviff/films.ts
@@ -57,8 +57,21 @@ export const minFilmYear = filmCountAvailableRows.reduce((min, row) => (row.tota
 export const latestScreeningsPerFilm = Math.round((latestClosedFilmYear.screenings! / latestClosedFilmYear.totalFilms!) * 100) / 100;
 export const firstScreeningsPerFilm = Math.round((filmScreeningRows[0].screenings! / filmScreeningRows[0].totalFilms!) * 100) / 100;
 
+function average(values: number[]) {
+  return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length);
+}
+
+function periodStats(fromYear: number, toYear: number) {
+  const rows = filmCountAvailableRows.filter((row) => row.year >= fromYear && row.year <= toYear);
+  const screeningRows = rows.filter((row): row is FilmCountRow & { screenings: number } => typeof row.screenings === 'number');
+  return {
+    avgFilms: average(rows.map((row) => row.totalFilms!)),
+    avgScreenings: average(screeningRows.map((row) => row.screenings)),
+  };
+}
+
 export const filmScaleByPeriod = [
-  { period: '1995-2003', label: 'Růst programu', avgFilms: 267, avgScreenings: 457 },
-  { period: '2004-2017', label: 'Stabilizace', avgFilms: 231, avgScreenings: 463 },
-  { period: '2018-2025', label: 'Menší katalog, hustší provoz', avgFilms: 181, avgScreenings: 470 },
-];
+  { period: '1995-2003', label: 'Růst programu', from: 1995, to: 2003 },
+  { period: '2004-2017', label: 'Stabilizace', from: 2004, to: 2017 },
+  { period: '2018-2025', label: 'Menší katalog, hustší provoz', from: 2018, to: 2025 },
+].map((row) => ({ ...row, ...periodStats(row.from, row.to) }));


### PR DESCRIPTION
## Summary
- Opravuje dvojí počítání kontinentů na mapě `/specialy/kviff/mapa-filmu`: nový generovaný `continents-history.ts` (z uživatelčina opraveného `kviff_continents_corrected_all_years.csv`) nahrazuje součet po jednotlivých zemích, který u koprodukcí se dvěma zeměmi ze stejného kontinentu počítal kontinent dvakrát.
- Vylepšuje UX `FilmOriginsDashboard`: mode-aware popisek karty „filmů v roce X" / „filmů celkem k roku X" (Ročně/Kumulativně), 100% lišta podílů kontinentů, kulaté play/pause tlačítko s ikonami místo textového „▶"/„II", menší mezery kolem mapy, procentuální podíl v tooltipu bublin, mini-tooltipy nad sloupci v popup grafu země.
- Opravuje `filmScaleByPeriod` v `films.ts` — počítá se teď z dat (`filmCountAvailableRows`) místo hardcoded čísel, což opravilo drobně nesedící `avgScreenings` (463→~465, 470→~467); `avgFilms` už sedělo.
- `FilmScreeningsChart`: přidána popsaná levá osa se sdíleným měřítkem pro sloupce filmy/projekce (dřív bez popisků, každý na vlastním maximu) + poznámka o nezávislých osách.
- Nová sekce „Blízký východ získává na mapě víc místa" s ověřeným vnitřním trendem KVIFF (2,1 % → 4,7 % → 6,7 % podílu na účastech produkčních zemí, 1992–2026).
- Drobná legenda u „Celá dostupná řada" (teal = má členění hrané/dok/krátké, šedá = jen celkový počet) — vysvětluje, že prázdné roky jsou záměr, ne chyba.
- Text „Program se po maximu zmenšil, ale zhoustl" byl ověřen číslo po čísle proti datům — beze změny, sedí přesně.

## Test plan
- [x] `npx tsc --noEmit` a `npx eslint` na dotčených souborech (bez nových chyb; jedna nesouvisející předexistující chyba v `ArticleRenderer.tsx`).
- [x] Ověřeno na lokálním dev serveru (port 3099 v tomto worktree) přes vykreslený text stránky `/specialy/kviff/mapa-filmu`: opravené hodnoty kontinentů (Evropa 2026 140 místo dřívějších chybných 250), mode-aware popisky, nová sekce Blízkého východu se správnými čísly, beze změny nesprávný text.
- [ ] Vizuální kontrola (spacing, ikony, tooltipy) – screenshoty se v tomto sezení nepodařilo pořídit kvůli problému s Browser pane nástrojem; doporučuji rychlou vizuální kontrolu na `/specialy/kviff/mapa-filmu` po sloučení.

🤖 Generated with [Claude Code](https://claude.com/claude-code)