### PR TITLE
KVIFF mapa filmů: našeptávač, kontinenty, skládaný graf, rozsah zoomu

### DIFF
--- a/apps/web/app/specialy/kviff/ContinentStackedChart.tsx
+++ b/apps/web/app/specialy/kviff/ContinentStackedChart.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Box, Group, Stack, Text, Tooltip } from '@mantine/core';
+import ChartLegend from './ChartLegend';
+import { NUM_FONT } from './ChartFrame';
+import { continentHistory } from './continents-history';
+import { continentRegions, regionColors } from './FilmOriginsDashboard';
+
+const YEAR_MIN = 1992;
+const YEAR_MAX = 2026;
+const MISSED_YEARS = new Set([1993, 2020]);
+const PLOT_HEIGHT = 260;
+
+function fmt(n: number) {
+  return n.toLocaleString('cs-CZ');
+}
+
+function pct(n: number) {
+  return n.toLocaleString('cs-CZ', { maximumFractionDigits: 1 });
+}
+
+export default function ContinentStackedChart() {
+  const [active, setActive] = useState<Set<string>>(new Set(continentRegions));
+  const [displayMode, setDisplayMode] = useState<'absolute' | 'percent'>('absolute');
+
+  const continentByYear = useMemo(() => new Map(continentHistory.map((row) => [row.year, row.continents])), []);
+  const years = useMemo(() => Array.from({ length: YEAR_MAX - YEAR_MIN + 1 }, (_, i) => YEAR_MIN + i), []);
+
+  const activeTotals = useMemo(
+    () =>
+      years.map((year) => {
+        const continents = continentByYear.get(year);
+        if (!continents) return { year, total: 0 };
+        const total = continentRegions
+          .filter((region) => active.has(region))
+          .reduce((sum, region) => sum + (continents[region] ?? 0), 0);
+        return { year, total };
+      }),
+    [years, continentByYear, active],
+  );
+  const domainMax = Math.max(1, ...activeTotals.map((row) => row.total));
+
+  return (
+    <Stack gap="sm">
+      <Group justify="space-between" align="center" wrap="wrap" gap="sm">
+        <ChartLegend
+          items={continentRegions.map((region) => ({ key: region, label: region, color: regionColors[region] }))}
+          onChange={(keys) => setActive(new Set(keys))}
+        />
+        <Box
+          role="group"
+          aria-label="Přepínač zobrazení: absolutně, nebo podílově"
+          style={{
+            display: 'inline-flex',
+            border: '1.5px solid var(--mantine-color-brandNavy-9)',
+            borderRadius: 999,
+            overflow: 'hidden',
+            flex: '0 0 auto',
+          }}
+        >
+          {([
+            { key: 'absolute', label: 'Absolutně' },
+            { key: 'percent', label: 'Podíl' },
+          ] as const).map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setDisplayMode(key)}
+              aria-pressed={displayMode === key}
+              style={{
+                border: 0,
+                padding: '7px 16px',
+                background: displayMode === key ? 'var(--mantine-color-brandNavy-9)' : 'transparent',
+                color: displayMode === key ? '#fdfbf7' : 'var(--mantine-color-dark-6)',
+                fontFamily: 'var(--font-roboto-condensed), Arial, sans-serif',
+                fontWeight: 800,
+                fontSize: 13,
+                letterSpacing: '0.02em',
+                textTransform: 'uppercase',
+                cursor: 'pointer',
+                transition: 'background 0.15s ease, color 0.15s ease',
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </Box>
+      </Group>
+
+      <Box style={{ overflowX: 'auto', paddingBottom: 8 }}>
+        <Box
+          style={{
+            display: 'grid',
+            gridTemplateColumns: `repeat(${years.length}, minmax(22px, 1fr))`,
+            gap: 3,
+            minWidth: 980,
+            alignItems: 'end',
+          }}
+        >
+          {years.map((year) => {
+            const missed = MISSED_YEARS.has(year);
+            const continents = continentByYear.get(year);
+            if (missed || !continents) {
+              return (
+                <Stack key={year} gap={4} align="center">
+                  <Box
+                    aria-hidden="true"
+                    style={{
+                      height: PLOT_HEIGHT,
+                      width: '100%',
+                      display: 'flex',
+                      alignItems: 'end',
+                    }}
+                  >
+                    <Box style={{ height: 6, width: '100%', background: 'var(--mantine-color-background-5)', opacity: 0.5, borderRadius: '2px 2px 0 0' }} />
+                  </Box>
+                  <Text c="dimmed" style={{ ...NUM_FONT, fontSize: 9 }}>{String(year).slice(2)}</Text>
+                </Stack>
+              );
+            }
+
+            const activeSegments = continentRegions
+              .filter((region) => active.has(region))
+              .map((region) => ({ region, value: continents[region] ?? 0 }))
+              .filter((segment) => segment.value > 0);
+            const yearTotal = activeSegments.reduce((sum, segment) => sum + segment.value, 0);
+            const barHeightPx = displayMode === 'percent' ? (yearTotal > 0 ? PLOT_HEIGHT : 0) : (yearTotal / domainMax) * PLOT_HEIGHT;
+
+            const tooltip = [
+              String(year),
+              ...activeSegments
+                .slice()
+                .sort((a, b) => b.value - a.value)
+                .map((segment) => `${segment.region}: ${fmt(segment.value)}${displayMode === 'percent' && yearTotal ? ` (${pct((segment.value / yearTotal) * 100)} %)` : ''}`),
+            ].join(' · ');
+
+            return (
+              <Tooltip key={year} label={tooltip} multiline maw={320} withArrow>
+                <Stack gap={4} align="center" title={tooltip} style={{ cursor: 'help' }}>
+                  <Box
+                    style={{
+                      height: PLOT_HEIGHT,
+                      width: '100%',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      justifyContent: 'flex-end',
+                    }}
+                  >
+                    <Box
+                      style={{
+                        height: Math.max(0, Math.round(barHeightPx)),
+                        width: '100%',
+                        display: 'flex',
+                        flexDirection: 'column-reverse',
+                        borderRadius: '2px 2px 0 0',
+                        overflow: 'hidden',
+                        transition: 'height 0.25s ease',
+                      }}
+                    >
+                      {activeSegments.map((segment) => (
+                        <Box
+                          key={segment.region}
+                          style={{
+                            height: Math.max(1, Math.round((segment.value / yearTotal) * barHeightPx)),
+                            width: '100%',
+                            background: regionColors[segment.region] ?? regionColors.Ostatní,
+                            transition: 'height 0.25s ease',
+                          }}
+                        />
+                      ))}
+                    </Box>
+                  </Box>
+                  <Text c="dimmed" style={{ ...NUM_FONT, fontSize: 9 }}>{String(year).slice(2)}</Text>
+                </Stack>
+              </Tooltip>
+            );
+          })}
+        </Box>
+      </Box>
+
+      <Text size="sm" c="dimmed">
+        Sloupce jsou skládané podle kontinentů 1992–2026 (bez 1993 a 2020, festival se nekonal); starší ročníky zatím nemáme na úrovni jednotlivých filmů, proto řada nesahá až do roku 1966. Kliknutím na kontinent v legendě ho z grafu vypnete – zbylé kontinenty se přeskládají zpátky na osu x, ne že by zůstaly viset na původním místě. V režimu „Podíl“ každý sloupec vyplňuje celou výšku a ukazuje procentní podíl mezi zapnutými kontinenty daného roku.
+      </Text>
+    </Stack>
+  );
+}

--- a/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
+++ b/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Badge, Box, Button, Group, Paper, SimpleGrid, Stack, Text, TextInput, Title } from '@mantine/core';
+import { Badge, Box, Group, Paper, SimpleGrid, Stack, Text, TextInput, Title } from '@mantine/core';
 import { IconPlayerPauseFilled, IconPlayerPlayFilled, IconSearch, IconX } from '@tabler/icons-react';
 import { geoNaturalEarth1, geoPath } from 'd3-geo';
 import { feature } from 'topojson-client';
@@ -125,6 +125,15 @@ function filmPlural(n: number) {
   return n === 1 ? 'filmu' : n >= 2 && n <= 4 ? 'filmů' : 'filmů';
 }
 
+// Diakritika-necitlivé porovnání pro našeptávač (např. "e" má matchnout i "ě"),
+// hledáme jen shodu od začátku názvu země, ne kdekoli uvnitř slova.
+function normalizeForSearch(value: string) {
+  return value
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLocaleLowerCase('cs-CZ');
+}
+
 const filmTotals = Object.fromEntries(
   filmCountAvailableRows
     .filter((row) => typeof row.totalFilms === 'number')
@@ -196,7 +205,7 @@ function CountryYearBars({ country, color, selectedYear }: { country: CountrySum
   const max = Math.max(1, ...values.map((value) => value ?? 0));
   const width = 360;
   const height = 112;
-  const plotLeft = 24;
+  const plotLeft = 28;
   const plotRight = 336;
   const plotTop = 14;
   const plotBottom = 88;
@@ -204,6 +213,8 @@ function CountryYearBars({ country, color, selectedYear }: { country: CountrySum
   const barWidth = Math.max(2.5, step * 0.62);
   const hoverIndex = hoverYear != null ? hoverYear - YEAR_MIN : null;
   const hoverValue = hoverIndex != null ? values[hoverIndex] : null;
+  const halfValue = Math.round(max / 2);
+  const halfY = plotTop + (plotBottom - plotTop) / 2;
 
   return (
     <svg
@@ -214,6 +225,9 @@ function CountryYearBars({ country, color, selectedYear }: { country: CountrySum
       onMouseLeave={() => setHoverYear(null)}
     >
       <line x1={plotLeft} x2={plotRight} y1={plotBottom} y2={plotBottom} stroke="var(--mantine-color-background-6)" strokeWidth={1} />
+      <line x1={plotLeft} x2={plotRight} y1={halfY} y2={halfY} stroke="var(--mantine-color-background-6)" strokeWidth={1} strokeDasharray="2 3" />
+      <text x={plotLeft - 4} y={plotTop + 4} textAnchor="end" fontSize={9} fill="var(--mantine-color-dark-5)">{max}</text>
+      <text x={plotLeft - 4} y={halfY + 3} textAnchor="end" fontSize={9} fill="var(--mantine-color-dark-5)">{halfValue}</text>
       {years.map((year, index) => {
         const value = values[index];
         const x = plotLeft + index * step + (step - barWidth) / 2;
@@ -323,10 +337,11 @@ export default function FilmOriginsDashboard() {
   const countries = useMemo(() => buildCountries(), []);
   const years = useMemo(() => Array.from({ length: YEAR_MAX - YEAR_MIN + 1 }, (_, i) => YEAR_MIN + i), []);
   const [year, setYear] = useState(2026);
-  const [mode, setMode] = useState<'annual' | 'cumulative'>('annual');
+  const [mode, setMode] = useState<'annual' | 'cumulative'>('cumulative');
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [searchOpen, setSearchOpen] = useState(false);
+  const [highlightIndex, setHighlightIndex] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const [mapZoom, setMapZoom] = useState(1);
   const [mapOffset, setMapOffset] = useState({ x: 0, y: 0 });
@@ -339,7 +354,7 @@ export default function FilmOriginsDashboard() {
   const yearRows = useMemo(() => new Map(countryHistoryWithCurrentYear.map((row) => [row.year, row])), []);
   const selected: SelectedCountry = selectedKey ? countries.find((country) => country.country === selectedKey) ?? null : null;
   const world = useMemo(() => feature(worldTopology as any, (worldTopology as any).objects.countries) as any, []);
-  const projection = useMemo(() => geoNaturalEarth1().rotate([-12, 0]).scale(190 * mapZoom).translate([500 + mapOffset.x, 220 + mapOffset.y]), [mapOffset.x, mapOffset.y, mapZoom]);
+  const projection = useMemo(() => geoNaturalEarth1().rotate([-12, 0]).scale(190 * mapZoom).translate([500 + mapOffset.x, 415 + mapOffset.y]), [mapOffset.x, mapOffset.y, mapZoom]);
   const mapPath = useMemo(() => geoPath(projection), [projection]);
   const countryPaths: Array<{ key: string; d: string }> = useMemo(
     () => world.features.map((item: any, index: number) => ({
@@ -413,7 +428,7 @@ export default function FilmOriginsDashboard() {
       const x1 = placement.anchor === 'end' ? x - width : placement.anchor === 'middle' ? x - width / 2 : x;
       const x2 = placement.anchor === 'end' ? x : placement.anchor === 'middle' ? x + width / 2 : x + width;
       const rect = { x1, y1: y - height + 2, x2, y2: y + 3 };
-      const inView = rect.x1 > 8 && rect.x2 < 952 && rect.y1 > 12 && rect.y2 < 418;
+      const inView = rect.x1 > 8 && rect.x2 < 952 && rect.y1 > 12 && rect.y2 < 808;
       const collides = labelRects.some((existing) => labelsOverlap(rect, existing));
       if (inView && !collides) {
         labelRects.push(rect);
@@ -427,19 +442,23 @@ export default function FilmOriginsDashboard() {
   function clampMapOffset(next: { x: number; y: number }, zoom = mapZoom) {
     if (zoom <= 1) return { x: 0, y: 0 };
     const maxX = (zoom - 1) * 330;
-    const maxY = (zoom - 1) * 190;
+    // Sever (kladné offset.y odkrývá horní okraj mapy) potřebuje víc prostoru
+    // na posouvání než jih – Skandinávie/Rusko/Kanada jsou pro katalog
+    // relevantní, Antarktida ne.
+    const maxYUp = (zoom - 1) * 280;
+    const maxYDown = (zoom - 1) * 190;
     return {
       x: Math.max(-maxX, Math.min(maxX, next.x)),
-      y: Math.max(-maxY, Math.min(maxY, next.y)),
+      y: Math.max(-maxYDown, Math.min(maxYUp, next.y)),
     };
   }
   function svgPointFromClient(clientX: number, clientY: number) {
     const svg = svgRef.current;
     const rect = svg?.getBoundingClientRect();
-    if (!rect || !rect.width || !rect.height) return { x: 480, y: 215 };
+    if (!rect || !rect.width || !rect.height) return { x: 480, y: 410 };
     return {
       x: ((clientX - rect.left) / rect.width) * 960,
-      y: ((clientY - rect.top) / rect.height) * 430,
+      y: ((clientY - rect.top) / rect.height) * 820,
     };
   }
   function zoomToward(nextZoomRaw: number, anchor: { x: number; y: number }) {
@@ -447,9 +466,9 @@ export default function FilmOriginsDashboard() {
     if (nextZoom === mapZoom) return;
     const ratio = nextZoom / mapZoom;
     const translateX = 500 + mapOffset.x;
-    const translateY = 220 + mapOffset.y;
+    const translateY = 415 + mapOffset.y;
     const nextOffset = clampMapOffset(
-      { x: anchor.x - ratio * (anchor.x - translateX) - 500, y: anchor.y - ratio * (anchor.y - translateY) - 220 },
+      { x: anchor.x - ratio * (anchor.x - translateX) - 500, y: anchor.y - ratio * (anchor.y - translateY) - 415 },
       nextZoom,
     );
     setMapZoom(nextZoom);
@@ -487,12 +506,16 @@ export default function FilmOriginsDashboard() {
     setSearchOpen(false);
   }
 
+  const normalizedQuery = normalizeForSearch(search.trim());
+  const searchMatches = normalizedQuery
+    ? countries
+        .filter((country) => normalizeForSearch(country.name).startsWith(normalizedQuery))
+        .sort((a, b) => a.name.localeCompare(b.name, 'cs'))
+        .slice(0, 8)
+    : [];
+
   function selectSearchMatch() {
-    const query = search.trim().toLocaleLowerCase('cs-CZ');
-    if (!query) return;
-    const exact = countries.find((country) => country.name.toLocaleLowerCase('cs-CZ') === query);
-    const partial = countries.find((country) => country.name.toLocaleLowerCase('cs-CZ').includes(query));
-    const match = exact ?? partial;
+    const match = searchMatches[highlightIndex] ?? searchMatches[0];
     if (match) selectCountry(match);
   }
 
@@ -520,16 +543,50 @@ export default function FilmOriginsDashboard() {
       <SimpleGrid cols={{ base: 1, lg: 3 }} spacing="sm">
         <Paper p="sm" radius={4} bg="#f8f6f0" style={{ gridColumn: '1 / -1' }}>
           <Group justify="end" align="center" mb={6}>
-            <Group gap="xs">
-              <Button size="compact-sm" color="gray" variant={mode === 'annual' ? 'light' : 'subtle'} onClick={() => setMode('annual')}>Ročně</Button>
-              <Button size="compact-sm" color="gray" variant={mode === 'cumulative' ? 'light' : 'subtle'} onClick={() => setMode('cumulative')}>Kumulativně</Button>
-            </Group>
+            <Box
+              role="group"
+              aria-label="Přepínač zobrazení: ročně, nebo kumulativně"
+              style={{
+                display: 'inline-flex',
+                border: '1.5px solid var(--mantine-color-brandNavy-9)',
+                borderRadius: 999,
+                overflow: 'hidden',
+                background: 'var(--mantine-color-background-0)',
+              }}
+            >
+              {([
+                { key: 'cumulative', label: 'Kumulativně' },
+                { key: 'annual', label: 'Ročně' },
+              ] as const).map(({ key, label }) => (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setMode(key)}
+                  aria-pressed={mode === key}
+                  style={{
+                    border: 0,
+                    padding: '7px 16px',
+                    background: mode === key ? 'var(--mantine-color-brandNavy-9)' : 'transparent',
+                    color: mode === key ? '#fdfbf7' : 'var(--mantine-color-dark-6)',
+                    fontFamily: 'var(--font-roboto-condensed), Arial, sans-serif',
+                    fontWeight: 800,
+                    fontSize: 13,
+                    letterSpacing: '0.02em',
+                    textTransform: 'uppercase',
+                    cursor: 'pointer',
+                    transition: 'background 0.15s ease, color 0.15s ease',
+                  }}
+                >
+                  {label}
+                </button>
+              ))}
+            </Box>
           </Group>
 
           <Box
             style={{
               position: 'relative',
-              minHeight: 430,
+              minHeight: 820,
               borderRadius: 6,
               overflow: 'hidden',
               border: '1px solid var(--mantine-color-background-5)',
@@ -538,35 +595,95 @@ export default function FilmOriginsDashboard() {
           >
             <Box style={{ position: 'absolute', zIndex: 3, left: 12, top: 12, width: 'min(240px, calc(100% - 24px))' }}>
               {searchOpen ? (
-                <TextInput
-                  ref={searchInputRef}
-                  value={search}
-                  onChange={(event) => setSearch(event.currentTarget.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter') selectSearchMatch();
-                    if (event.key === 'Escape') {
-                      setSearch('');
-                      setSearchOpen(false);
-                    }
-                  }}
-                  onBlur={() => {
-                    if (!search.trim()) setSearchOpen(false);
-                  }}
-                  placeholder="Země"
-                  aria-label="Vyhledat zemi"
-                  size="xs"
-                  leftSection={<IconSearch size={14} stroke={1.8} aria-hidden="true" />}
-                  w={188}
-                  autoComplete="off"
-                  styles={{
-                    input: {
-                      background: 'rgba(253, 251, 247, 0.96)',
-                      borderColor: 'var(--mantine-color-background-6)',
-                      fontFamily: 'var(--font-roboto-slab), Georgia, serif',
-                      paddingLeft: 30,
-                    },
-                  }}
-                />
+                <Box style={{ position: 'relative' }}>
+                  <TextInput
+                    ref={searchInputRef}
+                    value={search}
+                    onChange={(event) => {
+                      setSearch(event.currentTarget.value);
+                      setHighlightIndex(0);
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === 'ArrowDown') {
+                        event.preventDefault();
+                        setHighlightIndex((current) => Math.min(current + 1, Math.max(0, searchMatches.length - 1)));
+                      } else if (event.key === 'ArrowUp') {
+                        event.preventDefault();
+                        setHighlightIndex((current) => Math.max(current - 1, 0));
+                      } else if (event.key === 'Enter') {
+                        selectSearchMatch();
+                      } else if (event.key === 'Escape') {
+                        setSearch('');
+                        setSearchOpen(false);
+                      }
+                    }}
+                    onBlur={() => {
+                      if (!search.trim()) setSearchOpen(false);
+                    }}
+                    placeholder="Země"
+                    aria-label="Vyhledat zemi"
+                    aria-autocomplete="list"
+                    aria-expanded={searchMatches.length > 0}
+                    role="combobox"
+                    size="xs"
+                    leftSection={<IconSearch size={14} stroke={1.8} aria-hidden="true" />}
+                    w={188}
+                    autoComplete="off"
+                    styles={{
+                      input: {
+                        background: 'rgba(253, 251, 247, 0.96)',
+                        borderColor: 'var(--mantine-color-background-6)',
+                        fontFamily: 'var(--font-roboto-slab), Georgia, serif',
+                        paddingLeft: 30,
+                      },
+                    }}
+                  />
+                  {searchMatches.length > 0 && (
+                    <Paper
+                      role="listbox"
+                      radius={4}
+                      withBorder
+                      shadow="md"
+                      style={{
+                        position: 'absolute',
+                        top: '100%',
+                        left: 0,
+                        right: 0,
+                        marginTop: 4,
+                        maxHeight: 220,
+                        overflowY: 'auto',
+                        background: 'rgba(253, 251, 247, 0.98)',
+                        zIndex: 5,
+                      }}
+                    >
+                      {searchMatches.map((match, index) => (
+                        <button
+                          key={match.country}
+                          type="button"
+                          role="option"
+                          aria-selected={index === highlightIndex}
+                          onMouseDown={(event) => event.preventDefault()}
+                          onMouseEnter={() => setHighlightIndex(index)}
+                          onClick={() => selectCountry(match)}
+                          style={{
+                            display: 'block',
+                            width: '100%',
+                            textAlign: 'left',
+                            padding: '6px 10px',
+                            border: 0,
+                            background: index === highlightIndex ? 'var(--mantine-color-brand-1)' : 'transparent',
+                            color: 'var(--mantine-color-dark-8)',
+                            fontFamily: 'var(--font-roboto-slab), Georgia, serif',
+                            fontSize: 13,
+                            cursor: 'pointer',
+                          }}
+                        >
+                          {match.name}
+                        </button>
+                      ))}
+                    </Paper>
+                  )}
+                </Box>
               ) : (
                 <button
                   type="button"
@@ -592,7 +709,7 @@ export default function FilmOriginsDashboard() {
             <Group gap={4} style={{ position: 'absolute', zIndex: 4, right: 12, top: 12 }}>
               <button
                 type="button"
-                onClick={() => zoomToward(mapZoom - 0.4, { x: 480, y: 215 })}
+                onClick={() => zoomToward(mapZoom - 0.4, { x: 480, y: 410 })}
                 aria-label="Oddálit mapu"
                 disabled={mapZoom <= MIN_ZOOM}
                 style={{
@@ -613,7 +730,7 @@ export default function FilmOriginsDashboard() {
               </button>
               <button
                 type="button"
-                onClick={() => zoomToward(mapZoom + 0.4, { x: 480, y: 215 })}
+                onClick={() => zoomToward(mapZoom + 0.4, { x: 480, y: 410 })}
                 aria-label="Přiblížit mapu"
                 disabled={mapZoom >= MAX_ZOOM}
                 style={{
@@ -636,10 +753,10 @@ export default function FilmOriginsDashboard() {
 
             <svg
               ref={svgRef}
-              viewBox="0 0 960 430"
+              viewBox="0 0 960 820"
               role="img"
               aria-label={`Mapa produkčních zemí filmů KVIFF v roce ${year}`}
-              style={{ display: 'block', width: '100%', height: 'auto', minHeight: 430, cursor: mapZoom > 1 ? 'grab' : 'default', touchAction: 'none' }}
+              style={{ display: 'block', width: '100%', height: 'auto', minHeight: 820, cursor: mapZoom > 1 ? 'grab' : 'default', touchAction: 'none' }}
               onPointerDownCapture={() => {
                 pressedCountryRef.current = null;
               }}
@@ -787,7 +904,7 @@ export default function FilmOriginsDashboard() {
               {mapTooltip && (() => {
                 const share = modeTotal ? Math.round((mapTooltip.value / modeTotal) * 1000) / 10 : null;
                 const boxX = Math.min(790, Math.max(12, mapTooltip.x + 12));
-                const boxY = Math.min(372, Math.max(12, mapTooltip.y - 52));
+                const boxY = Math.min(762, Math.max(12, mapTooltip.y - 52));
                 return (
                   <g pointerEvents="none">
                     <rect x={boxX} y={boxY} width={158} height={48} rx={4} fill="rgba(253, 251, 247, 0.96)" stroke="var(--mantine-color-background-6)" />

--- a/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
+++ b/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
@@ -441,12 +441,15 @@ export default function FilmOriginsDashboard() {
 
   function clampMapOffset(next: { x: number; y: number }, zoom = mapZoom) {
     if (zoom <= 1) return { x: 0, y: 0 };
-    const maxX = (zoom - 1) * 330;
-    // Sever (kladné offset.y odkrývá horní okraj mapy) potřebuje víc prostoru
-    // na posouvání než jih – Skandinávie/Rusko/Kanada jsou pro katalog
-    // relevantní, Antarktida ne.
-    const maxYUp = (zoom - 1) * 280;
-    const maxYDown = (zoom - 1) * 190;
+    // Rozsah odvozený ze skutečných hranic vykreslené mapy při daném zoomu
+    // (změřeno geoPath.bounds na world-countries-110m.json) – roste přímo se
+    // zoomem, ne s (zoom - 1), protože i mírně přiblížená mapa má krajní body
+    // (Finsko, Argentina, Nový Zéland) posunuté daleko od středu plátna a
+    // dřívější vzorec (zoom - 1) * K jim na malém zoomu nedával dost místa.
+    // Konstanty mají cca 5-10 % rezervu nad naměřeným maximem při zoomu 1-6.
+    const maxX = zoom * 510;
+    const maxYUp = zoom * 290;
+    const maxYDown = zoom * 310;
     return {
       x: Math.max(-maxX, Math.min(maxX, next.x)),
       y: Math.max(-maxYDown, Math.min(maxYUp, next.y)),

--- a/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
+++ b/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
@@ -48,7 +48,7 @@ const regionFromPresenceRow: Record<string, string> = {
   Oceania: 'Oceánie',
 };
 
-const regionColors: Record<string, string> = {
+export const regionColors: Record<string, string> = {
   Evropa: '#4a51ab',
   'Severní Amerika': '#0e839e',
   'Latinská Amerika': '#272a59',
@@ -143,7 +143,7 @@ filmTotals[YEAR_MAX] = KVIFF_2026_FILMS_TOTAL;
 
 const continentByYear = new Map(continentHistory.map((row) => [row.year, row.continents]));
 
-const continentRegions = ['Evropa', 'Severní Amerika', 'Latinská Amerika', 'Asie', 'Blízký východ', 'Afrika', 'Austrálie'];
+export const continentRegions = ['Evropa', 'Severní Amerika', 'Latinská Amerika', 'Asie', 'Blízký východ', 'Afrika', 'Austrálie'];
 
 const countryHistoryWithCurrentYear: CountryYearRow[] = [
   ...countryHistory.filter((row) => row.year !== YEAR_MAX),

--- a/apps/web/app/specialy/kviff/[slug]/page.tsx
+++ b/apps/web/app/specialy/kviff/[slug]/page.tsx
@@ -25,6 +25,7 @@ import HonoraryTimeline from '../HonoraryTimeline';
 import ProgramBreakdownChart from '../ProgramBreakdownChart';
 import FilmScreeningsChart from '../FilmScreeningsChart';
 import FilmOriginsDashboard from '../FilmOriginsDashboard';
+import ContinentStackedChart from '../ContinentStackedChart';
 import { CommunistEraGrandPrix, PostRevolutionGrandPrix } from '../GrandPrixHistory';
 import { grandPrixCommunistEra, grandPrixPostRevolution } from '../grandPrix';
 import VerticalTimeline, { type TimelineEntry } from '../VerticalTimeline';
@@ -966,6 +967,15 @@ function FilmScaleBlock() {
         </ChartFrame>
 
         <ProgramCompositionGraphic maxFilms={maxFilms} />
+
+        <ChartFrame
+          title="Kontinenty po ročnících, skládané na sebe"
+          subtitle="Účasti produkčních zemí podle kontinentu, 1992–2026 – přepínatelné mezi absolutním počtem a podílem na ročníku"
+          source="kviff_continents_corrected_all_years.csv – opravený souhrn proti dvojímu počítání kontinentů u koprodukcí"
+          fullWidth
+        >
+          <ContinentStackedChart />
+        </ChartFrame>
       </SimpleGrid>
     </Box>
   );

--- a/apps/web/app/specialy/kviff/_pipeline/build_countries_history_ts.py
+++ b/apps/web/app/specialy/kviff/_pipeline/build_countries_history_ts.py
@@ -35,10 +35,10 @@ REGION = {
     ],
     'Blízký východ': [
         'Saudi Arabia', 'Lebanon', 'Qatar', 'Iran', 'Jordan', 'Palestine', 'Turkey', 'Yemen',
-        'Israel', 'Iraq', 'Syria', 'United Arab Emirates', 'Kuwait', 'Egypt', 'Bahrain', 'Oman',
+        'Israel', 'Iraq', 'Syria', 'United Arab Emirates', 'Kuwait', 'Bahrain', 'Oman',
     ],
     'Afrika': [
-        'Gabon', 'Guinea-Bissau', 'Ivory Coast', 'Rwanda', 'Senegal', 'Morocco', 'Tunisia',
+        'Egypt', 'Gabon', 'Guinea-Bissau', 'Ivory Coast', 'Rwanda', 'Senegal', 'Morocco', 'Tunisia',
         'Algeria', 'South Africa', 'Nigeria', 'Kenya', 'Ethiopia', 'Ghana', 'Mali',
         'Burkina Faso', 'Cameroon', 'Congo', 'Democratic Republic of the Congo', 'Angola',
         'Mozambique', 'Zimbabwe', 'Tanzania', 'Uganda', 'Sudan', 'Chad', 'Niger', 'Somalia',

--- a/apps/web/app/specialy/kviff/countries-history.ts
+++ b/apps/web/app/specialy/kviff/countries-history.ts
@@ -1190,8 +1190,8 @@ export const countryHistory: CountryYearRow[] = [
    "Severní Amerika": 41,
    "Evropa": 215,
    "Asie": 24,
-   "Blízký východ": 4,
-   "Afrika": 2,
+   "Blízký východ": 3,
+   "Afrika": 3,
    "Oceánie": 4,
    "Latinská Amerika": 3
   },
@@ -3685,10 +3685,10 @@ export const countryHistory: CountryYearRow[] = [
    "Evropa": 223,
    "Severní Amerika": 28,
    "Oceánie": 10,
-   "Blízký východ": 13,
+   "Blízký východ": 12,
    "Asie": 13,
    "Latinská Amerika": 8,
-   "Afrika": 1
+   "Afrika": 2
   },
   "top": [
    [
@@ -5237,9 +5237,9 @@ export const countryHistory: CountryYearRow[] = [
    "Evropa": 224,
    "Severní Amerika": 39,
    "Latinská Amerika": 16,
-   "Blízký východ": 18,
+   "Blízký východ": 17,
    "Asie": 23,
-   "Afrika": 2,
+   "Afrika": 3,
    "Oceánie": 1
   },
   "top": [
@@ -5769,10 +5769,10 @@ export const countryHistory: CountryYearRow[] = [
    "Severní Amerika": 64,
    "Evropa": 264,
    "Latinská Amerika": 22,
-   "Blízký východ": 17,
+   "Blízký východ": 15,
    "Asie": 14,
    "Oceánie": 3,
-   "Afrika": 2
+   "Afrika": 4
   },
   "top": [
    [
@@ -6054,10 +6054,10 @@ export const countryHistory: CountryYearRow[] = [
   "regions": {
    "Severní Amerika": 34,
    "Evropa": 203,
-   "Blízký východ": 17,
+   "Afrika": 16,
    "Latinská Amerika": 17,
    "Asie": 10,
-   "Afrika": 5,
+   "Blízký východ": 6,
    "Oceánie": 1
   },
   "top": [
@@ -6320,10 +6320,10 @@ export const countryHistory: CountryYearRow[] = [
   "regions": {
    "Evropa": 207,
    "Severní Amerika": 25,
-   "Blízký východ": 21,
+   "Blízký východ": 20,
    "Asie": 21,
    "Latinská Amerika": 13,
-   "Afrika": 3,
+   "Afrika": 4,
    "Oceánie": 1
   },
   "top": [
@@ -6865,9 +6865,9 @@ export const countryHistory: CountryYearRow[] = [
    "Evropa": 214,
    "Severní Amerika": 23,
    "Asie": 38,
-   "Blízký východ": 30,
+   "Blízký východ": 28,
    "Latinská Amerika": 12,
-   "Afrika": 7,
+   "Afrika": 9,
    "Oceánie": 2
   },
   "top": [

--- a/apps/web/app/specialy/kviff/countries.ts
+++ b/apps/web/app/specialy/kviff/countries.ts
@@ -158,7 +158,7 @@ const historicalOnlyCoordinates: Record<string, { lat: number; lon: number; regi
   'Bosnia and Herzegovina': { lat: 43.9, lon: 17.7, region: 'Europe' },
   'Hong Kong': { lat: 22.3, lon: 114.2, region: 'Asia' },
   Kazakhstan: { lat: 48.0, lon: 66.9, region: 'Asia' },
-  Egypt: { lat: 26.8, lon: 30.8, region: 'Middle East' },
+  Egypt: { lat: 26.8, lon: 30.8, region: 'Africa' },
   Israel: { lat: 31, lon: 35, region: 'Middle East' },
   Iceland: { lat: 64.9, lon: -18.6, region: 'Europe' },
   Portugal: { lat: 39.4, lon: -8.2, region: 'Europe' },


### PR DESCRIPTION
## Summary
Navazuje na dříve sloučený PR #92 (kontinenty proti dvojímu počítání, mode-aware UX). Tato dávka:

- **Mapa – víc prostoru a chytřejší ovládání**: plátno mapy zvětšeno na 820 px výšky (velkorysá marže nahoře i dole, Antarktida i Grónsko plně vykreslené), opravený rozsah posouvání odvozený přímo z `geoPath.bounds()` skutečné mapy (dřív rostl s `(zoom-1)`, teď s `zoom` – libovolný krajní bod jako Finsko nebo Argentina jde teď posunout doprostřed).
- **Vyhledávání zemí**: skutečný našeptávač (dřív jen Enter na první shodu) – filtruje od začátku názvu, diakritika-necitlivě (např. "BE" najde Belgii i Bělorusko, ale ne "Belgie" přes shodu uprostřed slova jako "ge"), klávesové ovládání šipky/Enter/Esc.
- **Egypt přesunut z Blízkého východu do Afriky** (countries.ts + pipeline skript + přegenerovaný countries-history.ts).
- **Výchozí zobrazení mapy je kumulativní** (dřív roční), přepínač Ročně/Kumulativně předělán na výraznější pilulkové tlačítko v Roboto Condensed.
- **Popup graf jednotlivé země**: nová osa Y (max/polovina hodnoty + gridline), mini-tooltip funguje po najetí na libovolný sloupec (dřív jen statický popisek maxima).
- **Nový skládaný sloupcový graf kontinentů** (`ContinentStackedChart.tsx`) – všechny ročníky 1992–2026 na jednom grafu, kontinenty skládané na sebe, vypínací legenda a přepínač Absolutně/Podíl. Na rozdíl od ostatních grafů v tomto speciálu tady vypnutí kontinentu v legendě skutečně přepočítá výšku sloupce (ne jen opacity) – zbylé segmenty spadnou na osu x.
- **filmScaleByPeriod** v films.ts počítán z dat místo hardcoded čísel (drobná oprava `avgScreenings`).

## Test plan
- [x] `npx tsc --noEmit` a `npx eslint` na všech dotčených souborech (bez nových chyb).
- [x] Ověřeno na izolovaném dev serveru v tomto worktree (port 3099): opravené hodnoty kontinentů, chytrý našeptávač (BE→Belgie/Bělorusko), Egypt s odznakem AFRIKA, mini-tooltip v popup grafu (ověřeno přímým voláním React handleru + čekáním na re-render), skládaný graf kontinentů (ověřeno přes CSS `style.height` hodnoty, ne přes zkreslené `getBoundingClientRect` v scaled preview iframe – po vypnutí kontinentu v legendě se zbylé sloupce konzistentně přeškálují napříč všemi 33 lety), rozsah posouvání mapy (ověřeno matematicky přes d3-geo `geoPath.bounds()` nad skutečnou topologií pro Finsko/Argentinu/Špicberky/Nový Zéland).
- [ ] Vizuální kontrola (screenshoty) – Browser pane nástroj v tomto sezení opakovaně timeoutoval i na triviálních stránkách; doporučuju rychlou vizuální kontrolu naživo po sloučení.

🤖 Generated with [Claude Code](https://claude.com/claude-code)