### PR TITLE
KVIFF mapa: menší čísla v hlavičce, opravená typová chyba po sloučení WorldMapViewport

### DIFF
--- a/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
+++ b/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
@@ -348,8 +348,8 @@ export default function FilmOriginsDashboard() {
   const [searchOpen, setSearchOpen] = useState(false);
   const [highlightIndex, setHighlightIndex] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [mapZoom, setMapZoom] = useState(WORLD_MAP_DEFAULT_VIEW.zoom);
-  const [mapOffset, setMapOffset] = useState({ ...WORLD_MAP_DEFAULT_VIEW.offset });
+  const [mapZoom, setMapZoom] = useState<number>(WORLD_MAP_DEFAULT_VIEW.zoom);
+  const [mapOffset, setMapOffset] = useState<{ x: number; y: number }>({ ...WORLD_MAP_DEFAULT_VIEW.offset });
   const [mapTooltip, setMapTooltip] = useState<MapTooltip>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);

--- a/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
+++ b/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
@@ -549,27 +549,27 @@ export default function FilmOriginsDashboard() {
   }
 
   return (
-    <Stack gap="md">
+    <Stack gap="xs">
       <SimpleGrid cols={{ base: 2, md: 4 }} spacing="sm">
-        <Paper p="md" radius={4} bg="#f8f6f0">
+        <Paper p="sm" radius={4} bg="#f8f6f0">
           <Text c="dimmed" size="sm">ročník</Text>
-          <Text fw={900} style={{ ...NUM_FONT, fontSize: 16 }}>{year}</Text>
+          <Text fw={900} style={{ ...NUM_FONT, fontSize: 20 }}>{year}</Text>
         </Paper>
-        <Paper p="md" radius={4} bg="#f8f6f0">
+        <Paper p="sm" radius={4} bg="#f8f6f0">
           <Text c="dimmed" size="sm">{countriesCardLabel}</Text>
-          <Text fw={900} style={{ ...NUM_FONT, fontSize: 16 }}>{fmt(countriesForCard)}</Text>
+          <Text fw={900} style={{ ...NUM_FONT, fontSize: 20 }}>{fmt(countriesForCard)}</Text>
         </Paper>
-        <Paper p="md" radius={4} bg="#f8f6f0">
+        <Paper p="sm" radius={4} bg="#f8f6f0">
           <Text c="dimmed" size="sm">{coproductionsCardLabel}</Text>
-          <Text fw={900} style={{ ...NUM_FONT, fontSize: 16 }}>{fmt(coproductionsForCard)}</Text>
+          <Text fw={900} style={{ ...NUM_FONT, fontSize: 20 }}>{fmt(coproductionsForCard)}</Text>
         </Paper>
-        <Paper p="md" radius={4} bg="#f8f6f0">
+        <Paper p="sm" radius={4} bg="#f8f6f0">
           <Text c="dimmed" size="sm">{filmsCardLabel}</Text>
-          <Text fw={900} style={{ ...NUM_FONT, fontSize: 16 }}>{fmt(filmsForCard)}</Text>
+          <Text fw={900} style={{ ...NUM_FONT, fontSize: 20 }}>{fmt(filmsForCard)}</Text>
         </Paper>
       </SimpleGrid>
 
-      <SimpleGrid cols={{ base: 1, lg: 3 }} spacing="sm">
+      <SimpleGrid cols={{ base: 1, lg: 3 }} spacing="xs">
         <Paper p="sm" radius={4} bg="#f8f6f0" style={{ gridColumn: '1 / -1' }}>
           <Group justify="end" align="center" mb={6}>
             <Box


### PR DESCRIPTION
## Summary
- Čísla v hlavičce mapy (ročník, zemí, koprodukcí, filmů) zmenšena na 20px – stejná velikost jako titulek grafu. Sloučeno s mezitímní opravou na main (mode-aware kartičky zemí/koprodukcí) – zachována jejich logika, jen sjednocena velikost a zmenšeny mezery pod hlavičkou a pod patičkou mapy.
- Oprava TypeScript chyby, která vznikla po sloučení sdíleného `WorldMapViewport` standardu z `main` – `WORLD_MAP_DEFAULT_VIEW` je deklarovaný přes `as const`, takže `useState(WORLD_MAP_DEFAULT_VIEW.zoom)` se bez explicitní anotace odvodil na literální typ místo `number`. Přidána explicitní anotace typu.
- Ověřeno geometricky (d3-geo + reálná topologie), že rozsah posouvání mapy zůstal funkční i po sloučení sdíleného standardu (Finsko i Argentina jdou dostat do středu).

## Test plan
- [x] `npx tsc --noEmit` – bez chyb (dřív 5 chyb kvůli literálním typům).
- [x] `npx eslint` – bez nových chyb.
- [x] Geometrická verifikace rozsahu posouvání mapy po sloučení WorldMapViewport standardu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)