### PR TITLE
KVIFF mapa: oprava češtiny u počtu filmů a zjednodušená věta v panelu

### DIFF
--- a/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
+++ b/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
@@ -128,7 +128,7 @@ function pct(n: number) {
 }
 
 function filmPlural(n: number) {
-  return n === 1 ? 'filmu' : n >= 2 && n <= 4 ? 'filmů' : 'filmů';
+  return n === 1 ? 'film' : n >= 2 && n <= 4 ? 'filmy' : 'filmů';
 }
 
 // Diakritika-necitlivé porovnání pro našeptávač (např. "e" má matchnout i "ě"),
@@ -910,7 +910,7 @@ export default function FilmOriginsDashboard() {
                     vectorEffect="non-scaling-stroke"
                     tabIndex={value ? 0 : -1}
                     role="button"
-                    aria-label={`${country.name}: uvedeno u ${value} ${filmPlural(value)}`}
+                    aria-label={`${country.name}: ${value} ${filmPlural(value)}`}
                     style={{ cursor: value ? 'pointer' : 'default', transition: 'r .24s ease, opacity .24s ease' }}
                     onPointerDown={() => {
                       if (value) pressedCountryRef.current = country;
@@ -1018,7 +1018,7 @@ export default function FilmOriginsDashboard() {
                 </Group>
                 <Text size="sm" c="dimmed" mt="xs">
                   {annualValue
-                    ? `${selected.name} je uvedeno u ${fmt(annualValue)} ${filmPlural(annualValue)} v roce ${year}.`
+                    ? `${fmt(annualValue)} ${filmPlural(annualValue)} v roce ${year}.`
                     : `V roce ${year} se v katalogu neobjevuje.`}
                 </Text>
                 {selectedProgramShare != null && <Box mt="sm"><ShareBar value={selectedProgramShare} color={selectedColor} /></Box>}


### PR DESCRIPTION
## Summary
- `filmPlural` opraven: 1 film, 2–4 filmy, 5+ filmů (dřív vracel genitivní "filmu"/"filmů" i pro nominativní kontext, takže bylo "1 filmu" a "2 filmů" místo "1 film" a "2 filmy").
- Odstraněno kostrbaté „[Země] je uvedeno u X filmů v roce Y." v panelu vybrané země – jméno země je vidět v titulku panelu nad tím, takže věta teď zní jen „X filmů v roce Y." Stejná úprava v aria-label bublin na mapě (dřív „Francie: uvedeno u 36 filmů", teď „Francie: 36 filmů").

## Test plan
- [x] `npx tsc --noEmit` a `npx eslint` – bez chyb.
- [x] Ověřeno na dev serveru: Francie → „36 filmů v roce 2026.", bubliny na mapě → „1 film", „2 filmy", „5 filmů", „10 filmů", „31 filmů" (přesně podle zadání).

🤖 Generated with [Claude Code](https://claude.com/claude-code)