### PR TITLE
KVIFF mapa: potlačen výchozí focus rámeček kolem bublin zemí

### DIFF
--- a/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
+++ b/apps/web/app/specialy/kviff/FilmOriginsDashboard.tsx
@@ -911,7 +911,7 @@ export default function FilmOriginsDashboard() {
                     tabIndex={value ? 0 : -1}
                     role="button"
                     aria-label={`${country.name}: ${value} ${filmPlural(value)}`}
-                    style={{ cursor: value ? 'pointer' : 'default', transition: 'r .24s ease, opacity .24s ease' }}
+                    style={{ cursor: value ? 'pointer' : 'default', transition: 'r .24s ease, opacity .24s ease', outline: 'none' }}
                     onPointerDown={() => {
                       if (value) pressedCountryRef.current = country;
                     }}


### PR DESCRIPTION
## Summary
Bublina země je focusovatelný SVG prvek (`role="button"`, `tabIndex`). Po kliknutí prohlížeč sám navíc kreslí obdélníkový focus rámeček kolem bounding boxu bubliny, nad rámec našeho vlastního zvýraznění (silnější/tmavší kruhový obrys). Přidán `outline: 'none'` – zvýraznění kroužkem zůstává jediným vizuálním indikátorem výběru, žádný extra rámeček.

## Test plan
- [x] Ověřeno na dev serveru: po fokusu bubliny je `outlineStyle: 'none'` (dřív by prohlížeč kreslil výchozí rámeček).
- [x] Barevné zvýraznění kroužkem (`stroke`/`strokeWidth`) beze změny.
- [x] `npx eslint` – bez chyb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)