### PR TITLE
README jako vstupní brána + prominentní odkaz na redakční manuál

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,23 @@
-# Turborepo starter
+# Mahdalová & Škop · DataTimes
+
+Monorepo datové žurnalistiky dvojice Kateřina Mahdalová & Michal Škop. Obsahuje oba weby a všechny speciály:
+
+- **`apps/web`** — [mahdalova-skop.cz](https://www.mahdalova-skop.cz) (česky)
+- **`apps/datajournalism.studio`** — [datajournalism.studio](https://www.datajournalism.studio) (anglicky)
+
+## 📘 Jak píšeme, ověřujeme a navrhujeme
+
+**[REDAKCNI_MANUAL.md](REDAKCNI_MANUAL.md) — kanonický redakční manuál.** Jediný zdroj pravdy: etika a styl závazně pro všechny formáty (text, data, audio, video), žánry, fact-checking a provoz. Platí pro obě značky i všechny speciály.
+
+Podřízené a doplňkové dokumenty:
+- [STYL_DATOVA_ZURNALISTIKA.md](STYL_DATOVA_ZURNALISTIKA.md) — datová žurnalistika s příklady (hloubková reference)
+- [NAVOD_STYL_TRESNAK.md](NAVOD_STYL_TRESNAK.md) — replikovatelná metoda vyprávěcího stylu
+- [DESIGN.md](DESIGN.md) — vizuální systém a barevné tokeny
+- Projektové kapitoly: [`apps/web/SPECIAL.md`](apps/web/SPECIAL.md) a [`apps/web/DPBP_WRITING_GUIDE.md`](apps/web/DPBP_WRITING_GUIDE.md) (Data pro budoucí premiérku), [`apps/web/KVIFF_WRITING_GUIDE.md`](apps/web/KVIFF_WRITING_GUIDE.md) (Karlovy Vary v datech)
+
+---
+
+## Technická dokumentace (Turborepo)
 
 This is an official starter Turborepo.
 

--- a/REDAKCNI_MANUAL.md
+++ b/REDAKCNI_MANUAL.md
@@ -1,6 +1,8 @@
 # Redakční manuál DataTimes — kanonická verze
 
-Jediný zdroj pravdy pro to, jak píšeme, ověřujeme a navrhujeme. **Etika a srozumitelný styl platí závazně pro všechny naše analýzy bez ohledu na formát** — text, data, grafiku, audio i video. Žánry určují stavbu. Vzhled a lokální nuance doplňují projektové kapitoly.
+Jediný zdroj pravdy pro to, jak píšeme, ověřujeme a navrhujeme ve všem, co dělá dvojice Mahdalová & Škop. **Etika a srozumitelný styl platí závazně pro všechny naše analýzy bez ohledu na formát** — text, data, grafiku, audio i video — a napříč oběma značkami (mahdalova-skop.cz i datajournalism.studio) a všemi speciály. Žánry určují stavbu. Vzhled a lokální nuance doplňují projektové kapitoly.
+
+*Umístění: kořen repozitáře `mahdalova-skop`. Tohle je kanonická strojově i lidsky čitelná verze; čtenářský booklet (.docx) se z ní odvozuje.*
 
 Tenhle soubor nahrazuje roztříštěnost pravidel mezi dokumenty. Hlubší rozbory zůstávají jako podřízené reference (viz [Registr](#registr-zdrojů-a-projektových-kapitol)); žádný z nich nesmí tenhle manuál oslabit ani vytvořit druhou „ústavu".
 


### PR DESCRIPTION
Kořenový README byl jen default Turborepo starter, takže manuál nešel z repa najít. Nově README pojmenovává projekt, oba weby a odkazuje REDAKCNI_MANUAL.md i podřízené dokumenty. Úvod manuálu výslovně jmenuje obě značky a potvrzuje umístění v kořeni repa. Bez zásahu do produkčního kódu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)